### PR TITLE
fix: downgraded meta package to version 1.15.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   pointycastle: ^3.9.1
   bip32: ^2.0.0
   base_codecs: ^1.0.1
-  meta: ^1.16.0
+  meta: ^1.15.0
   ed25519_edwards: ^0.3.1
   ed25519_hd_key: ^2.2.0
   x25519: ^0.1.1


### PR DESCRIPTION
**Problem**
Many public packages are still using meta package version 1.15.0.
Flutter_test embedded in flutter version 3.27.0 also still has dependency on version 1.15.0
Because of this when integrating affinidi-ssi package, using pub get reports a version solving failure.  

**Solution**
Downgraded meta package to version 1.15.0