### PR TITLE
fix: making the interface of issue methods uniform.

### DIFF
--- a/doc/credentials/code_snippets/vc_issuance.dart
+++ b/doc/credentials/code_snippets/vc_issuance.dart
@@ -24,7 +24,7 @@ Future<void> main() async {
   final credential = MutableVcDataModelV2(
       context: [DMV2ContextUrl],
       id: Uri.parse('urn:uuid:1234abcd-1234-abcd-1234-abcd1234abcd'),
-      issuer: Issuer.uri('did:example:issuer'),
+      issuer: Issuer.uri(signer.did),
       type: {'VerifiableCredential', 'UniversityDegreeCredential'},
       validFrom: DateTime.parse('2023-01-01T12:00:00Z'),
       validUntil: DateTime.parse('2028-01-01T12:00:00Z'),
@@ -39,8 +39,9 @@ Future<void> main() async {
       ]);
 
   // Issue the VC
-  final credentialToSign = VcDataModelV2.fromJson(credential.toJson());
-  final issuedCredential = await suite.issue(credentialToSign, signer);
+  final credentialToSign = VcDataModelV2.fromMutable(credential);
+  final issuedCredential =
+      await suite.issue(unsignedData: credentialToSign, signer: signer);
 
   // Print the serialized credential
   print('Issued VC:\n${issuedCredential.serialized}');

--- a/doc/credentials/code_snippets/vp_v1_issuance.dart
+++ b/doc/credentials/code_snippets/vp_v1_issuance.dart
@@ -3,6 +3,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:ssi/src/credentials/models/field_types/holder.dart';
 import 'package:ssi/src/credentials/models/v1/vc_data_model_v1.dart';
 import 'package:ssi/src/credentials/proof/ecdsa_secp256k1_signature2019_suite.dart';
 import 'package:ssi/ssi.dart';
@@ -29,6 +30,7 @@ Future<void> main() async {
     context: [DMV1ContextUrl],
     id: Uri.parse('testVpV1Id'),
     type: {'VerifiablePresentation'},
+    holder: MutableHolder.uri(signer.did),
     verifiableCredential: [ldV1VC, jwtV1VC],
   );
 
@@ -38,11 +40,9 @@ Future<void> main() async {
   );
 
   // Issue the VP using the V1 suite
-  final vpToSign = VpDataModelV1.fromJson(v1Vp.toJson());
-  final issuedVp = await LdVpDm1Suite().issue(
-      unsignedData: vpToSign,
-      issuer: signer.did,
-      proofGenerator: proofGenerator);
+  final vpToSign = VpDataModelV1.fromMutable(v1Vp);
+  final issuedVp = await LdVpDm1Suite()
+      .issue(unsignedData: vpToSign, proofGenerator: proofGenerator);
 
   // Output result
   print('Serialized VP:\n${issuedVp.serialized}');

--- a/doc/credentials/code_snippets/vp_v2_issuance.dart
+++ b/doc/credentials/code_snippets/vp_v2_issuance.dart
@@ -3,6 +3,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:ssi/src/credentials/models/field_types/holder.dart';
 import 'package:ssi/src/credentials/models/v2/vc_data_model_v2.dart';
 import 'package:ssi/src/credentials/proof/ecdsa_secp256k1_signature2019_suite.dart';
 import 'package:ssi/ssi.dart';
@@ -32,6 +33,7 @@ Future<void> main() async {
       context: [DMV2ContextUrl],
       id: Uri.parse('testVpV2'),
       type: {'VerifiablePresentation'},
+      holder: MutableHolder.uri(signer.did),
       verifiableCredential: [ldV1VC, ldV2VC, sdjwtV2VC]);
 
   // create a proof Generator
@@ -40,11 +42,9 @@ Future<void> main() async {
   );
 
   // Issue the VP using the V2 suite
-  final vpToSign = VpDataModelV2.fromJson(v2Vp.toJson());
-  final issuedVp = await LdVpDm2Suite().issue(
-      unsignedData: vpToSign,
-      issuer: signer.did,
-      proofGenerator: proofGenerator);
+  final vpToSign = VpDataModelV2.fromMutable(v2Vp);
+  final issuedVp = await LdVpDm2Suite()
+      .issue(unsignedData: vpToSign, proofGenerator: proofGenerator);
 
   // Output result
   print('Serialized VP:\n${issuedVp.serialized}');

--- a/lib/src/credentials/jwt/jwt_dm_v1_suite.dart
+++ b/lib/src/credentials/jwt/jwt_dm_v1_suite.dart
@@ -9,15 +9,11 @@ import '../suites/vc_suite.dart';
 
 part 'jwt_data_model_v1.dart';
 
-class JwtOptions {}
-
 /// Class to parse and convert JWT token strings into a [VerifiableCredential]
 final class JwtDm1Suite
-    with
-        JwtParser
+    with JwtParser
     implements
-        VerifiableCredentialSuite<String, VcDataModelV1, JwtVcDataModelV1,
-            JwtOptions> {
+        VerifiableCredentialSuite<String, VcDataModelV1, JwtVcDataModelV1> {
   /// Checks if the [data] provided matches the right criteria to attempt a parse
   /// [data] must be a valid jwt string with a header a payload and a signature
   @override
@@ -43,11 +39,16 @@ final class JwtDm1Suite
   }
 
   Future<JwtVcDataModelV1> issue(
-    VcDataModelV1 vc,
-    DidSigner signer, {
-    JwtOptions? options,
-  }) async {
-    final (header, payload) = JwtVcDataModelV1.vcToJws(vc.toJson(), signer);
+      {required VcDataModelV1 unsignedData, required DidSigner signer}) async {
+    if (signer.did != unsignedData.issuer.id.toString()) {
+      throw SsiException(
+        message: 'Issuer mismatch',
+        code: SsiExceptionType.invalidJson.code,
+      );
+    }
+
+    final (header, payload) =
+        JwtVcDataModelV1.vcToJws(unsignedData.toJson(), signer);
 
     final encodedHeader = base64UrlNoPadEncode(
       utf8.encode(jsonEncode(header)),

--- a/lib/src/credentials/linked_data/ld_dm_v1_suite.dart
+++ b/lib/src/credentials/linked_data/ld_dm_v1_suite.dart
@@ -6,14 +6,10 @@ import '../models/verifiable_credential.dart';
 import '../suites/vc_suite.dart';
 import 'ld_base_suite.dart';
 
-class LdVcDm1Options extends LdOptions {}
-
 /// Class to parse and convert a json representation of a [VerifiableCredential]
-final class LdVcDm1Suite
-    extends LdBaseSuite<VcDataModelV1, LdVcDataModelV1, LdVcDm1Options>
+final class LdVcDm1Suite extends LdBaseSuite<VcDataModelV1, LdVcDataModelV1>
     implements
-        VerifiableCredentialSuite<String, VcDataModelV1, LdVcDataModelV1,
-            LdVcDm1Options> {
+        VerifiableCredentialSuite<String, VcDataModelV1, LdVcDataModelV1> {
   LdVcDm1Suite()
       : super(
           contextUrl: DMV1ContextUrl,

--- a/lib/src/credentials/linked_data/ld_dm_v2_suite.dart
+++ b/lib/src/credentials/linked_data/ld_dm_v2_suite.dart
@@ -6,14 +6,10 @@ import '../models/verifiable_credential.dart';
 import '../suites/vc_suite.dart';
 import 'ld_base_suite.dart';
 
-class LdVcDm2Options extends LdOptions {}
-
 /// Class to parse and convert a json representation of a [VerifiableCredential]
-final class LdVcDm2Suite
-    extends LdBaseSuite<VcDataModelV2, LdVcDataModelV2, LdVcDm2Options>
+final class LdVcDm2Suite extends LdBaseSuite<VcDataModelV2, LdVcDataModelV2>
     implements
-        VerifiableCredentialSuite<String, VcDataModelV2, LdVcDataModelV2,
-            LdVcDm2Options> {
+        VerifiableCredentialSuite<String, VcDataModelV2, LdVcDataModelV2> {
   LdVcDm2Suite()
       : super(
           contextUrl: DMV2ContextUrl,

--- a/lib/src/credentials/models/v1/vc_data_model_v1.dart
+++ b/lib/src/credentials/models/v1/vc_data_model_v1.dart
@@ -234,4 +234,7 @@ class VcDataModelV1 implements VerifiableCredential {
             refreshService: input.refreshService,
             termsOfUse: input.termsOfUse,
             evidence: input.evidence);
+
+  factory VcDataModelV1.fromMutable(MutableVcDataModelV1 data) =>
+      VcDataModelV1.fromJson(data.toJson());
 }

--- a/lib/src/credentials/models/v2/vc_data_model_v2.dart
+++ b/lib/src/credentials/models/v2/vc_data_model_v2.dart
@@ -219,4 +219,7 @@ class VcDataModelV2 implements VerifiableCredential {
             refreshService: input.refreshService,
             termsOfUse: input.termsOfUse,
             evidence: input.evidence);
+
+  factory VcDataModelV2.fromMutable(MutableVcDataModelV2 data) =>
+      VcDataModelV2.fromJson(data.toJson());
 }

--- a/lib/src/credentials/presentations/linked_data/ld_vp_dm_v1_suite.dart
+++ b/lib/src/credentials/presentations/linked_data/ld_vp_dm_v1_suite.dart
@@ -6,18 +6,13 @@ import '../models/parsed_vp.dart';
 import '../models/v1/vp_data_model_v1.dart';
 import '../suites/vp_suite.dart';
 
-/// Options specific to Linked Data VPv1 operations.
-class LdVpDm1Options extends LdOptions {}
-
 /// Implementation for parsing and processing JSON-LD Verifiable Presentations v1.1.
 ///
 /// Handles the parsing, validation, and processing of W3C Verifiable Presentations
 /// following the Data Model v1.1 specification in JSON-LD format.
-final class LdVpDm1Suite
-    extends LdBaseSuite<VpDataModelV1, LdVpDataModelV1, LdVpDm1Options>
+final class LdVpDm1Suite extends LdBaseSuite<VpDataModelV1, LdVpDataModelV1>
     implements
-        VerifiablePresentationSuite<String, VpDataModelV1, LdVpDataModelV1,
-            LdVpDm1Options> {
+        VerifiablePresentationSuite<String, VpDataModelV1, LdVpDataModelV1> {
   /// Creates a new [LdVpDm1Suite] with the v1.1 context URL.
   LdVpDm1Suite()
       : super(

--- a/lib/src/credentials/presentations/linked_data/ld_vp_dm_v2_suite.dart
+++ b/lib/src/credentials/presentations/linked_data/ld_vp_dm_v2_suite.dart
@@ -6,18 +6,13 @@ import '../models/parsed_vp.dart';
 import '../models/v2/vp_data_model_v2.dart';
 import '../suites/vp_suite.dart';
 
-/// Options specific to Linked Data VPv2 operations.
-class LdVpDm2Options extends LdOptions {}
-
 /// Implementation for parsing and processing JSON-LD Verifiable Presentations v2.2.
 ///
 /// Handles the parsing, validation, and processing of W3C Verifiable Presentations
 /// following the Data Model v2.2 specification in JSON-LD format.
-final class LdVpDm2Suite
-    extends LdBaseSuite<VpDataModelV2, LdVpDataModelV2, LdVpDm2Options>
+final class LdVpDm2Suite extends LdBaseSuite<VpDataModelV2, LdVpDataModelV2>
     implements
-        VerifiablePresentationSuite<String, VpDataModelV2, LdVpDataModelV2,
-            LdVpDm2Options> {
+        VerifiablePresentationSuite<String, VpDataModelV2, LdVpDataModelV2> {
   /// Creates a new [LdVpDm2Suite] with the v2.2 context URL.
   LdVpDm2Suite()
       : super(

--- a/lib/src/credentials/presentations/models/v1/vp_data_model_v1.dart
+++ b/lib/src/credentials/presentations/models/v1/vp_data_model_v1.dart
@@ -164,4 +164,7 @@ class VpDataModelV1 implements VerifiablePresentation {
             holder: input.holder,
             verifiableCredential: input.verifiableCredential,
             proof: input.proof);
+
+  factory VpDataModelV1.fromMutable(MutableVpDataModelV1 data) =>
+      VpDataModelV1.fromJson(data.toJson());
 }

--- a/lib/src/credentials/presentations/models/v2/vp_data_model_v2.dart
+++ b/lib/src/credentials/presentations/models/v2/vp_data_model_v2.dart
@@ -179,4 +179,7 @@ class VpDataModelV2 implements VerifiablePresentation {
             verifiableCredential: input.verifiableCredential,
             proof: input.proof,
             termsOfUse: input.termsOfUse);
+
+  factory VpDataModelV2.fromMutable(MutableVpDataModelV2 data) =>
+      VpDataModelV2.fromJson(data.toJson());
 }

--- a/lib/src/credentials/presentations/suites/vp_suite.dart
+++ b/lib/src/credentials/presentations/suites/vp_suite.dart
@@ -5,8 +5,7 @@ import '../models/verifiable_presentation.dart';
 abstract class VerifiablePresentationSuite<
     SerializedType,
     VP extends VerifiablePresentation,
-    ParsedVP extends ParsedVerifiablePresentation<SerializedType>,
-    Options> {
+    ParsedVP extends ParsedVerifiablePresentation<SerializedType>> {
   /// Determines whether the provided [data] can be parsed by this suite.
   bool canParse(Object data);
 

--- a/lib/src/credentials/sdjwt/enveloped_vc_suite.dart
+++ b/lib/src/credentials/sdjwt/enveloped_vc_suite.dart
@@ -17,9 +17,6 @@ final Map<String, VerifiableCredentialSuite> mediaTypeSuites = {
   MediaTypes.sdJwt.type: SdJwtDm2Suite()
 };
 
-/// Options for SD-JWT Data Model v2 operations.
-class EnvelopedVcDm2Options {}
-
 /// Suite for working with W3C VC Data Model v2 credentials in SD-JWT format.
 ///
 /// Provides methods to parse, validate, and issue Verifiable Credentials
@@ -30,7 +27,7 @@ final class EnvelopedVcDm2Suite
         LdParser
     implements
         VerifiableCredentialSuite<String, VcDataModelV2,
-            ParsedVerifiableCredential<String>, EnvelopedVcDm2Options> {
+            ParsedVerifiableCredential<String>> {
   @override
   bool hasValidPayload(Map<String, dynamic> data) {
     final context = data[VcDataModelV2Key.context.key];
@@ -72,17 +69,6 @@ final class EnvelopedVcDm2Suite
 
     return mediaType.value.parse(serialized)
         as ParsedVerifiableCredential<String>;
-  }
-
-  Future<SdJwtDataModelV2> issue(
-    VcDataModelV2 vc,
-    DidSigner signer, {
-    EnvelopedVcDm2Options? options,
-  }) async {
-    throw SsiException(
-      message: 'Cannot issue an enveloped VC.',
-      code: SsiExceptionType.unsupportedEnvelopeVCOperation.code,
-    );
   }
 
   @override

--- a/lib/src/credentials/sdjwt/sdjwt_dm_v2_suite.dart
+++ b/lib/src/credentials/sdjwt/sdjwt_dm_v2_suite.dart
@@ -13,51 +13,15 @@ import '../suites/vc_suite.dart';
 import 'enveloped_vc_suite.dart';
 import 'sdjwt_did_verifier.dart';
 
-/// Options for SD-JWT Data Model v2 operations.
-///
-/// Contains configuration parameters for selective disclosure JWT operations
-/// in the context of W3C Verifiable Credentials Data Model v2.
-class SdJwtDm2Options {
-  /// Defines which fields in the VC should be selectively disclosable.
-  ///
-  /// A map structure that specifies which parts of the credential should be
-  /// made available for selective disclosure.
-  final Map<String, dynamic>? disclosureFrame;
-
-  /// Hasher implementation for generating disclosure digests.
-  ///
-  /// Defaults to SHA-256 algorithm for hashing if not specified.
-  final Hasher<String, String>? hasher;
-
-  /// The holder's public key for binding the credential to the holder.
-  ///
-  /// Used for key binding to ensure the credential can only be presented
-  /// by the intended holder.
-  final SdPublicKey? holderPublicKey;
-
-  /// Creates an options object for SD-JWT Data Model v2 operations.
-  ///
-  /// [disclosureFrame] - Specifies which fields should be selectively disclosable.
-  /// [hasher] - The hashing algorithm implementation to use for disclosures.
-  /// [holderPublicKey] - Public key of the credential holder for key binding.
-  SdJwtDm2Options({
-    this.disclosureFrame,
-    this.hasher,
-    this.holderPublicKey,
-  });
-}
-
 /// Suite for working with W3C VC Data Model v2 credentials in SD-JWT format.
 ///
 /// Provides methods to parse, validate, and issue Verifiable Credentials
 /// represented as Selective Disclosure JWT (SD-JWT) according to the
 /// W3C Data Model v2 specification.
 final class SdJwtDm2Suite
-    with
-        SdJwtParser
+    with SdJwtParser
     implements
-        VerifiableCredentialSuite<String, VcDataModelV2, SdJwtDataModelV2,
-            SdJwtDm2Options> {
+        VerifiableCredentialSuite<String, VcDataModelV2, SdJwtDataModelV2> {
   /// Checks if the SD-JWT payload represents a valid VC Data Model v2 structure.
   ///
   /// [data] - The SD-JWT structure to validate.
@@ -106,26 +70,39 @@ final class SdJwtDm2Suite
 
   /// Issues a new SD-JWT credential by signing the VC with the provided signer.
   ///
-  /// [vc] - The credential to be issued.
+  /// [unsignedData] - The credential to be issued.
   /// [signer] - The DID signer used to sign the credential.
-  /// [options] - Optional configuration for the SD-JWT issuance.
+  /// [disclosureFrame] - (optional) Defines which fields in the VC should be selectively disclosable.
+  /// A map structure that specifies which parts of the credential should be
+  /// made available for selective disclosure.
+  /// [hasher] - (optional) Hasher implementation for generating disclosure digests.
+  /// Defaults to SHA-256 algorithm for hashing if not specified.
+  /// [holderPublicKey] - (optional) The holder's public key for binding the credential to the holder.
+  /// Used for key binding to ensure the credential can only be presented
+  /// by the intended holder.
   ///
   /// Returns a parsed SD-JWT credential with appropriate signatures and disclosures.
   ///
   /// Throws [SsiException] if the credential is invalid or if signing fails.
   Future<SdJwtDataModelV2> issue(
-    VcDataModelV2 vc,
-    DidSigner signer, {
-    SdJwtDm2Options? options,
-  }) async {
-    final payload = vc.toJson();
+      {required VcDataModelV2 unsignedData,
+      required DidSigner signer,
+      Map<String, dynamic>? disclosureFrame,
+      Hasher<String, String>? hasher,
+      SdPublicKey? holderPublicKey}) async {
+    final payload = unsignedData.toJson();
 
-    payload[VcDataModelV2Key.issuer.key] = signer.did;
+    if (signer.did != unsignedData.issuer.id.toString()) {
+      throw SsiException(
+        message: 'Issuer mismatch',
+        code: SsiExceptionType.invalidJson.code,
+      );
+    }
 
     final jwtClaims = <String, dynamic>{};
     jwtClaims.addAll(payload);
-    final disclosureFrame =
-        options?.disclosureFrame ?? _getDefaultDisclosureFrame(payload);
+    disclosureFrame ??= _getDefaultDisclosureFrame(payload);
+
     final jwtSigner = _createSdJwtSigner(signer);
     final handler = SdJwtHandlerV1();
 
@@ -134,8 +111,8 @@ final class SdJwtDm2Suite
         claims: jwtClaims,
         disclosureFrame: disclosureFrame,
         signer: jwtSigner,
-        hasher: options?.hasher ?? Base64EncodedOutputHasher.base64Sha256,
-        holderPublicKey: options?.holderPublicKey,
+        hasher: hasher ?? Base64EncodedOutputHasher.base64Sha256,
+        holderPublicKey: holderPublicKey,
       );
       return SdJwtDataModelV2.fromSdJwt(await sdJwt);
     } catch (e, stacktrace) {

--- a/lib/src/credentials/suites/vc_suite.dart
+++ b/lib/src/credentials/suites/vc_suite.dart
@@ -5,8 +5,7 @@ import '../models/verifiable_credential.dart';
 abstract interface class VerifiableCredentialSuite<
     SerializedType,
     VC extends VerifiableCredential,
-    ParsedVC extends ParsedVerifiableCredential<SerializedType>,
-    Options> {
+    ParsedVC extends ParsedVerifiableCredential<SerializedType>> {
   /// Determines whether the provided [data] can be parsed by this suite.
   bool canParse(Object data);
 

--- a/test/credentials/presentations/issuance/ld_vp_v1_test.dart
+++ b/test/credentials/presentations/issuance/ld_vp_v1_test.dart
@@ -35,8 +35,7 @@ void main() async {
         signer: signer,
       );
       final issuedPresentation = await LdVpDm1Suite().issue(
-          unsignedData: VpDataModelV1.fromJson(v1Vp.toJson()),
-          issuer: signer.did,
+          unsignedData: VpDataModelV1.fromMutable(v1Vp),
           proofGenerator: proofGenerator);
       expect(issuedPresentation, isNotNull);
       expect(issuedPresentation.serialized, isNotNull);

--- a/test/credentials/presentations/issuance/ld_vp_v2_test.dart
+++ b/test/credentials/presentations/issuance/ld_vp_v2_test.dart
@@ -37,8 +37,7 @@ void main() async {
         signer: signer,
       );
       final issuedPresentation = await LdVpDm2Suite().issue(
-          unsignedData: VpDataModelV2.fromJson(v2Vp.toJson()),
-          issuer: signer.did,
+          unsignedData: VpDataModelV2.fromMutable(v2Vp),
           proofGenerator: proofGenerator);
 
       expect(issuedPresentation, isNotNull);

--- a/test/credentials/presentations/verification/ld_vp_v1_domain_challenge_test.dart
+++ b/test/credentials/presentations/verification/ld_vp_v1_domain_challenge_test.dart
@@ -30,8 +30,7 @@ void main() async {
       final proofGenerator = Secp256k1Signature2019Generator(
           signer: signer, domain: ['fun.com'], challenge: 'test-challenge');
       var issuedCredential = await LdVpDm1Suite().issue(
-          unsignedData: VpDataModelV1.fromJson(v1Vp.toJson()),
-          issuer: signer.did,
+          unsignedData: VpDataModelV1.fromMutable(v1Vp),
           proofGenerator: proofGenerator);
 
       final verificationStatus = await VpDomainChallengeVerifier(
@@ -45,8 +44,7 @@ void main() async {
       final proofGenerator = Secp256k1Signature2019Generator(
           signer: signer, domain: ['fun.com'], challenge: 'test-challenge');
       var issuedCredential = await LdVpDm1Suite().issue(
-          unsignedData: VpDataModelV1.fromJson(v1Vp.toJson()),
-          issuer: signer.did,
+          unsignedData: VpDataModelV1.fromMutable(v1Vp),
           proofGenerator: proofGenerator);
 
       final verificationStatus = await VpDomainChallengeVerifier(
@@ -60,8 +58,7 @@ void main() async {
       final proofGenerator = Secp256k1Signature2019Generator(
           signer: signer, domain: ['fun.com'], challenge: 'test-challenge');
       var issuedCredential = await LdVpDm1Suite().issue(
-          unsignedData: VpDataModelV1.fromJson(v1Vp.toJson()),
-          issuer: signer.did,
+          unsignedData: VpDataModelV1.fromMutable(v1Vp),
           proofGenerator: proofGenerator);
 
       final verificationStatus = await VpDomainChallengeVerifier(

--- a/test/credentials/presentations/verification/ld_vp_v2_domain_challenge_test.dart
+++ b/test/credentials/presentations/verification/ld_vp_v2_domain_challenge_test.dart
@@ -30,8 +30,7 @@ void main() async {
       final proofGenerator = Secp256k1Signature2019Generator(
           signer: signer, domain: ['fun.com'], challenge: 'test-challenge');
       var issuedCredential = await LdVpDm2Suite().issue(
-          unsignedData: VpDataModelV2.fromJson(v2Vp.toJson()),
-          issuer: signer.did,
+          unsignedData: VpDataModelV2.fromMutable(v2Vp),
           proofGenerator: proofGenerator);
 
       final verificationStatus = await VpDomainChallengeVerifier(
@@ -45,8 +44,7 @@ void main() async {
       final proofGenerator = Secp256k1Signature2019Generator(
           signer: signer, domain: ['fun.com'], challenge: 'test-challenge');
       var issuedCredential = await LdVpDm2Suite().issue(
-          unsignedData: VpDataModelV2.fromJson(v2Vp.toJson()),
-          issuer: signer.did,
+          unsignedData: VpDataModelV2.fromMutable(v2Vp),
           proofGenerator: proofGenerator);
 
       final verificationStatus = await VpDomainChallengeVerifier(
@@ -60,8 +58,7 @@ void main() async {
       final proofGenerator = Secp256k1Signature2019Generator(
           signer: signer, domain: ['fun.com'], challenge: 'test-challenge');
       var issuedCredential = await LdVpDm2Suite().issue(
-          unsignedData: VpDataModelV2.fromJson(v2Vp.toJson()),
-          issuer: signer.did,
+          unsignedData: VpDataModelV2.fromMutable(v2Vp),
           proofGenerator: proofGenerator);
 
       final verificationStatus = await VpDomainChallengeVerifier(

--- a/test/credentials/proof/ld_vc_issuer_model_v1_test.dart
+++ b/test/credentials/proof/ld_vc_issuer_model_v1_test.dart
@@ -52,8 +52,7 @@ void main() async {
       );
 
       final issuedCredential = await LdVcDm1Suite().issue(
-        issuer: signer.did,
-        unsignedData: VcDataModelV1.fromJson(unsignedCredential.toJson()),
+        unsignedData: VcDataModelV1.fromMutable(unsignedCredential),
         proofGenerator: proofGenerator,
       );
 
@@ -89,16 +88,19 @@ void main() async {
     });
 
     test('LdVCDM1 fixture VC verify', () async {
-      final unsigned = LdVcDm1Suite().parse(VerifiableCredentialDataFixtures
-          .credentialWithValidProofDataModelV11JsonEncoded);
+      final unsigned = MutableVcDataModelV1.fromJson(LdVcDm1Suite()
+          .parse(VerifiableCredentialDataFixtures
+              .credentialWithValidProofDataModelV11JsonEncoded)
+          .toJson());
+
+      unsigned.issuer = MutableIssuer.uri(signer.did);
 
       final proofGenerator = Secp256k1Signature2019Generator(
         signer: signer,
       );
 
       final issuedCredential = await LdVcDm1Suite().issue(
-        issuer: signer.did,
-        unsignedData: unsigned,
+        unsignedData: VcDataModelV1.fromMutable(unsigned),
         proofGenerator: proofGenerator,
       );
 

--- a/test/credentials/proof/ld_vc_issuer_model_v2_test.dart
+++ b/test/credentials/proof/ld_vc_issuer_model_v2_test.dart
@@ -49,8 +49,7 @@ void main() {
         signer: signer,
       );
       final issuedCredential = await LdVcDm2Suite().issue(
-          unsignedData: VcDataModelV2.fromJson(unsignedCredential.toJson()),
-          issuer: signer.did,
+          unsignedData: VcDataModelV2.fromMutable(unsignedCredential),
           proofGenerator: proofGenerator);
 
       final verificationResult =

--- a/test/credentials/sdjwt/sdjwt_issuance_test.dart
+++ b/test/credentials/sdjwt/sdjwt_issuance_test.dart
@@ -26,7 +26,7 @@ void main() {
       final credential = MutableVcDataModelV2(
         context: [DMV2ContextUrl],
         id: Uri.parse('urn:uuid:1234abcd-1234-abcd-1234-abcd1234abcd'),
-        issuer: Issuer.uri('did:example:issuer'),
+        issuer: Issuer.uri(signer.did),
         type: {'VerifiableCredential', 'UniversityDegreeCredential'},
         validFrom: DateTime.parse('2023-01-01T12:00:00Z'),
         validUntil: DateTime.parse('2028-01-01T12:00:00Z'),
@@ -42,7 +42,7 @@ void main() {
       );
 
       final issuedCredential = await suite.issue(
-          VcDataModelV2.fromJson(credential.toJson()), signer);
+          unsignedData: VcDataModelV2.fromMutable(credential), signer: signer);
 
       expect(issuedCredential, isNotNull);
       expect(issuedCredential.serialized, isNotNull);
@@ -72,7 +72,7 @@ void main() {
       final credential = MutableVcDataModelV2(
         context: [DMV2ContextUrl],
         id: Uri.parse('urn:uuid:1234abcd-1234-abcd-1234-abcd1234abcd'),
-        issuer: Issuer.uri('did:example:issuer'),
+        issuer: Issuer.uri(signer.did),
         type: {'VerifiableCredential', 'UniversityDegreeCredential'},
         validFrom: DateTime.parse('2023-01-01T12:00:00Z'),
         validUntil: DateTime.parse('2028-01-01T12:00:00Z'),
@@ -100,11 +100,9 @@ void main() {
       };
 
       final issuedCredential = await suite.issue(
-        VcDataModelV2.fromJson(credential.toJson()),
-        signer,
-        options: SdJwtDm2Options(
-          disclosureFrame: disclosureFrame,
-        ),
+        unsignedData: VcDataModelV2.fromMutable(credential),
+        signer: signer,
+        disclosureFrame: disclosureFrame,
       );
 
       expect(issuedCredential, isNotNull);
@@ -127,7 +125,8 @@ void main() {
 
       expect(
         () => suite.issue(
-            VcDataModelV2.fromJson(invalidCredential.toJson()), signer),
+            unsignedData: VcDataModelV2.fromMutable(invalidCredential),
+            signer: signer),
         throwsA(isA<SsiException>()),
       );
     });

--- a/test/verifiable_credential_test.dart
+++ b/test/verifiable_credential_test.dart
@@ -1,5 +1,6 @@
 import 'package:base_codecs/base_codecs.dart';
 import 'package:ssi/src/credentials/jwt/jwt_dm_v1_suite.dart';
+import 'package:ssi/src/credentials/models/field_types/issuer.dart';
 import 'package:ssi/src/credentials/models/v1/vc_data_model_v1.dart';
 import 'package:ssi/ssi.dart';
 import 'package:test/test.dart';
@@ -177,12 +178,14 @@ void main() {
       test(
         'it can encode & decode',
         () async {
-          final dataModel = VcDataModelV1.fromJson(
+          final dataModel = MutableVcDataModelV1.fromJson(
             VerifiableCredentialDataFixtures.credentialWithoutProofDataModelV11,
-          );
+          )..issuer = MutableIssuer.uri(signer.did);
 
           final suite = JwtDm1Suite();
-          final jwt = await suite.issue(dataModel, signer);
+          final jwt = await suite.issue(
+              unsignedData: VcDataModelV1.fromMutable(dataModel),
+              signer: signer);
 
           var actualIntegrity = await suite.verifyIntegrity(jwt);
 


### PR DESCRIPTION
- making the interface of issue methods uniform across suites. 
- The unsigned payload already needs to set the issuer or holder, as this is verified when we construct the `VcDataModel` from the mutable payload. 
- It is not proper for `issue` method to unilaterally modify the value of the `issuer` that is already set in the `unsigned` payload. We don't have to modify the payload during issuance, only verify it's values.
