### PR TITLE
feat: add missing public api members docs under /credentials 

### DIFF
--- a/lib/src/credentials/jwt/jwt_data_model_v1.dart
+++ b/lib/src/credentials/jwt/jwt_data_model_v1.dart
@@ -4,8 +4,10 @@ part of 'jwt_dm_v1_suite.dart';
 /// Example: https://www.w3.org/TR/vc-data-model/#example-verifiable-credential-using-jwt-compact-serialization-non-normative
 class JwtVcDataModelV1 extends VcDataModelV1
     implements ParsedVerifiableCredential<String> {
+  /// The decoded JWS (JSON Web Signature) object.
   final Jws jws;
 
+  /// Creates a [JwtVcDataModelV1] instance from a [Jws].
   JwtVcDataModelV1.fromJws(this.jws)
       : super.clone(VcDataModelV1.fromJson(jwtToJson(jws.payload)));
 
@@ -17,6 +19,9 @@ class JwtVcDataModelV1 extends VcDataModelV1
     return jws.payload['vc'] as Map<String, dynamic>;
   }
 
+  /// Converts a VC JSON object to a pair of JWT header and payload.
+  ///
+  /// This prepares the data for signing as a JWT.
   static (Map<String, dynamic> header, Map<String, dynamic> payload) vcToJws(
     Map<String, dynamic> json,
     DidSigner signer,
@@ -57,6 +62,7 @@ class JwtVcDataModelV1 extends VcDataModelV1
     return (header, payload);
   }
 
+  /// Converts a JWT payload back into a VC JSON object.
   static Map<String, dynamic> jwtToJson(Map<String, dynamic> payload) {
     final json = payload['vc'] as Map<String, dynamic>;
 

--- a/lib/src/credentials/jwt/jwt_dm_v1_suite.dart
+++ b/lib/src/credentials/jwt/jwt_dm_v1_suite.dart
@@ -9,6 +9,9 @@ import '../suites/vc_suite.dart';
 
 part 'jwt_data_model_v1.dart';
 
+/// Options for configuring JWT issuance or parsing.
+class JwtOptions {}
+
 /// Class to parse and convert JWT token strings into a [VerifiableCredential]
 final class JwtDm1Suite
     with JwtParser
@@ -38,6 +41,9 @@ final class JwtDm1Suite
     return JwtVcDataModelV1.fromJws(jws);
   }
 
+  /// Issues a signed [JwtVcDataModelV1] from a [VcDataModelV1] using a [DidSigner].
+  ///
+  /// Optionally takes [options] for JWT issuance configuration.
   Future<JwtVcDataModelV1> issue(
       {required VcDataModelV1 unsignedData, required DidSigner signer}) async {
     if (signer.did != unsignedData.issuer.id.toString()) {

--- a/lib/src/credentials/linked_data/ld_base_suite.dart
+++ b/lib/src/credentials/linked_data/ld_base_suite.dart
@@ -13,12 +13,21 @@ import '../proof/embedded_proof_suite.dart';
 /// Class to parse and convert a json representation of a [VerifiableCredential]
 abstract class LdBaseSuite<VC extends DocWithEmbeddedProof, Model extends VC>
     with LdParser {
+  /// The required context url
   final String contextUrl;
 
+  /// The JSON key used for the proof object (default: 'proof').
   final String proofKey;
+
+  /// The JSON key used for the context object (default: '@context').
   final String contextKey;
+
+  /// The JSON key used for the issuer field (default: 'issuer').
   final String issuerKey;
 
+  /// Constructs a new [LdBaseSuite] with the required context URL.
+  ///
+  /// Optional [proofKey], [contextKey], and [issuerKey] parameters
   LdBaseSuite({
     required this.contextUrl,
     this.proofKey = 'proof',
@@ -35,14 +44,21 @@ abstract class LdBaseSuite<VC extends DocWithEmbeddedProof, Model extends VC>
     return (context is List) && context.contains(contextUrl);
   }
 
+  /// Checks if the given [input] can be parsed.
+  ///
+  /// Returns `true` if [input] is a String and can be decoded into a JSON object.
   bool canParse(Object input) {
     if (input is! String) return false;
 
     return canDecode(input);
   }
 
+  /// Creates a [Model] instance from the parsed JSON [payload] and original [input] string.
   Model fromParsed(String input, Map<String, dynamic> payload);
 
+  /// Issues a signed [Model] by applying an embedded proof.
+  ///
+  /// Throws a [SsiException] if the issuer in the proof does not match the credential's
   Future<Model> issue({
     required VC unsignedData,
     required EmbeddedProofGenerator proofGenerator,
@@ -66,6 +82,9 @@ abstract class LdBaseSuite<VC extends DocWithEmbeddedProof, Model extends VC>
     return fromParsed(jsonEncode(json), json);
   }
 
+  /// Parses the [input] string into a [Model].
+  ///
+  /// Throws a [SsiException] if [input] is not a valid String.
   Model parse(Object input) {
     if (input is! String) {
       throw SsiException(
@@ -77,6 +96,9 @@ abstract class LdBaseSuite<VC extends DocWithEmbeddedProof, Model extends VC>
     return fromParsed(input, decode(input));
   }
 
+  /// Verifies the cryptographic integrity of the [input] credential.
+  ///
+  /// Optionally accepts [getNow] to provide a custom "now" time for expiry and validity
   Future<bool> verifyIntegrity(Model input,
       {DateTime Function() getNow = DateTime.now}) async {
     //TODO(FTL-20735): discover proof type
@@ -90,6 +112,7 @@ abstract class LdBaseSuite<VC extends DocWithEmbeddedProof, Model extends VC>
     return verificationResult.isValid;
   }
 
+  /// Presents the [input] credential as a JSON object.
   Map<String, dynamic> present(Model input) {
     return input.toJson();
   }

--- a/lib/src/credentials/linked_data/ld_dm_v1_suite.dart
+++ b/lib/src/credentials/linked_data/ld_dm_v1_suite.dart
@@ -10,6 +10,7 @@ import 'ld_base_suite.dart';
 final class LdVcDm1Suite extends LdBaseSuite<VcDataModelV1, LdVcDataModelV1>
     implements
         VerifiableCredentialSuite<String, VcDataModelV1, LdVcDataModelV1> {
+  /// Constructs a [LdVcDm1Suite] using the predefined [DMV1ContextUrl].
   LdVcDm1Suite()
       : super(
           contextUrl: DMV1ContextUrl,
@@ -20,10 +21,15 @@ final class LdVcDm1Suite extends LdBaseSuite<VcDataModelV1, LdVcDataModelV1>
       LdVcDataModelV1.fromParsed(input, payload);
 }
 
+/// A [VcDataModelV1] backed by a parsed JSON-LD serialized string.
+///
+/// Implements the [ParsedVerifiableCredential] interface.
 class LdVcDataModelV1 extends VcDataModelV1
     implements ParsedVerifiableCredential<String> {
+  /// The serialized JSON string representation of the credential.
   final String _serialized;
 
+  /// Creates a [LdVcDataModelV1] from a serialized [String] and parsed [input] map.
   LdVcDataModelV1.fromParsed(String serialized, Map<String, dynamic> input)
       : _serialized = serialized,
         super.clone(VcDataModelV1.fromJson(input));

--- a/lib/src/credentials/linked_data/ld_dm_v2_suite.dart
+++ b/lib/src/credentials/linked_data/ld_dm_v2_suite.dart
@@ -10,6 +10,7 @@ import 'ld_base_suite.dart';
 final class LdVcDm2Suite extends LdBaseSuite<VcDataModelV2, LdVcDataModelV2>
     implements
         VerifiableCredentialSuite<String, VcDataModelV2, LdVcDataModelV2> {
+  /// Constructs a [LdVcDm2Suite] using the predefined [DMV2ContextUrl].
   LdVcDm2Suite()
       : super(
           contextUrl: DMV2ContextUrl,
@@ -20,10 +21,15 @@ final class LdVcDm2Suite extends LdBaseSuite<VcDataModelV2, LdVcDataModelV2>
       LdVcDataModelV2.fromParsed(input, payload);
 }
 
+/// A [VcDataModelV2] backed by a parsed JSON-LD serialized string.
+///
+/// Implements the [ParsedVerifiableCredential] interface.
 class LdVcDataModelV2 extends VcDataModelV2
     implements ParsedVerifiableCredential<String> {
+  /// The serialized JSON string representation of the credential.
   final String _serialized;
 
+  /// Creates a [LdVcDataModelV2] from a serialized [String] and parsed [input] map.
   LdVcDataModelV2.fromParsed(String serialized, Map<String, dynamic> input)
       : _serialized = serialized,
         super.clone(VcDataModelV2.fromJson(input));

--- a/lib/src/credentials/proof/data_integrity_proof.dart
+++ b/lib/src/credentials/proof/data_integrity_proof.dart
@@ -1,3 +1,0 @@
-// class DataIntegrityProof extends EmbeddedProofSuite {
-//
-// }

--- a/lib/src/credentials/proof/ecdsa_secp256k1_signature2019_suite.dart
+++ b/lib/src/credentials/proof/ecdsa_secp256k1_signature2019_suite.dart
@@ -18,10 +18,20 @@ final _sha256 = Digest('SHA-256');
 const _signatureType = 'EcdsaSecp256k1Signature2019';
 const _securityContext = 'https://w3id.org/security/v2';
 
+/// Generates Linked Data Proofs using the EcdsaSecp256k1Signature2019 signature suite.
+///
+/// Signs Verifiable Credentials by normalizing the credential and the proof separately,
+/// hashing them, and then signing the combined hash using a [DidSigner].
 class Secp256k1Signature2019Generator extends EmbeddedProofSuiteCreateOptions
     implements EmbeddedProofGenerator {
+  /// The DID signer used to produce the proof signature.
   final DidSigner signer;
 
+  /// Constructs a new [Secp256k1Signature2019Generator].
+  ///
+  /// [signer]: The DID signer responsible for creating the proof signature.
+  /// Optional parameters like [proofPurpose], [customDocumentLoader], [expires],
+  /// [challenge], and [domain] configure the proof metadata.
   Secp256k1Signature2019Generator({
     required this.signer,
     super.proofPurpose,
@@ -31,6 +41,8 @@ class Secp256k1Signature2019Generator extends EmbeddedProofSuiteCreateOptions
     super.domain,
   });
 
+  /// Generates an [EmbeddedProof] for the given [document].
+  @override
   Future<EmbeddedProof> generate(Map<String, dynamic> document) async {
     final created = DateTime.now();
     final proof = {
@@ -91,13 +103,30 @@ class Secp256k1Signature2019Generator extends EmbeddedProofSuiteCreateOptions
   }
 }
 
+/// Verifies Linked Data Proofs signed with the EcdsaSecp256k1Signature2019 signature suite.
+///
+/// Normalizes and hashes the credential and proof separately, then verifies
+/// the combined hash against the provided proof signature using the issuer's DID key.
 class Secp256k1Signature2019Verifier extends EmbeddedProofSuiteVerifyOptions
     implements EmbeddedProofVerifier {
+  /// The DID of the issuer expected to have signed the credential.
   final String issuerDid;
+
+  /// Function to supply the current timestamp for proof expiry validation.
   final DateTime Function() getNow;
+
+  /// Optional domain to validate within the proof.
   final List<String>? domain;
+
+  /// Optional challenge string to validate within the proof.
   final String? challenge;
 
+  /// Constructs a new [Secp256k1Signature2019Verifier].
+  ///
+  /// [issuerDid]: The expected issuer DID.
+  /// [getNow]: Optional time supplier (defaults to `DateTime.now`).
+  /// [domain]: Optional expected domain(s).
+  /// [challenge]: Optional expected challenge string.
   Secp256k1Signature2019Verifier({
     required this.issuerDid,
     this.getNow = DateTime.now,
@@ -106,6 +135,9 @@ class Secp256k1Signature2019Verifier extends EmbeddedProofSuiteVerifyOptions
     super.customDocumentLoader,
   });
 
+  /// Verifies the proof embedded in the provided [document].
+  ///
+  /// Returns a [VerificationResult] indicating success or listing errors.
   @override
   Future<VerificationResult> verify(Map<String, dynamic> document,
       {DateTime Function() getNow = DateTime.now}) async {
@@ -151,9 +183,18 @@ class Secp256k1Signature2019Verifier extends EmbeddedProofSuiteVerifyOptions
   }
 }
 
+/// Data model representing a Linked Data Proof of type EcdsaSecp256k1Signature2019.
+///
+/// Contains signature metadata and the actual JWS signature.
 class EcdsaSecp256k1Signature2019Proof extends EmbeddedProof {
+  /// The JWS (JSON Web Signature) string that signs the normalized data.
+
   final String jws;
 
+  /// Constructs a new [EcdsaSecp256k1Signature2019Proof].
+  ///
+  /// Required fields include [type], [created], [verificationMethod], [proofPurpose], and [jws].
+  /// Optional fields include [expires], [challenge], and [domain].
   EcdsaSecp256k1Signature2019Proof(
       {required super.type,
       required super.created,

--- a/lib/src/credentials/proof/embedded_proof.dart
+++ b/lib/src/credentials/proof/embedded_proof.dart
@@ -48,6 +48,7 @@ class EmbeddedProof {
   /// Additional properties (from Proof).
   final Map<String, dynamic>? additionalProperties;
 
+  /// Constructs an [EmbeddedProof].
   EmbeddedProof({
     this.id,
     required this.type,

--- a/lib/src/credentials/sdjwt/enveloped_vc_suite.dart
+++ b/lib/src/credentials/sdjwt/enveloped_vc_suite.dart
@@ -6,13 +6,17 @@ import '../suites/vc_suite.dart';
 import '../suites/vc_suites.dart';
 import 'sdjwt_dm_v2_suite.dart';
 
+/// Enum representing supported media types for enveloped Verifiable Credentials.
 enum MediaTypes {
+  /// Media type for SD-JWT encoded Verifiable Credentials.
   sdJwt('data:application/vc+sd-jwt,');
 
+  /// The associated media type string.
   final String type;
   const MediaTypes(this.type);
 }
 
+/// Mapping between media type strings and their corresponding VC suites.
 final Map<String, VerifiableCredentialSuite> mediaTypeSuites = {
   MediaTypes.sdJwt.type: SdJwtDm2Suite()
 };
@@ -44,12 +48,18 @@ final class EnvelopedVcDm2Suite
         mediaTypeSuites.keys.any(envelopedData.startsWith);
   }
 
+  /// Checks if [input] can be parsed by this suite.
+  ///
+  /// Returns `true` if [input] is a decodable String.
   @override
   bool canParse(Object input) {
     if (input is! String) return false;
     return canDecode(input);
   }
 
+  /// Parses an [input] string into a [ParsedVerifiableCredential].
+  ///
+  /// Throws a [SsiException] if [input] is not a String or invalid.
   @override
   ParsedVerifiableCredential<String> parse(Object input) {
     if (input is! String) {

--- a/lib/src/credentials/sdjwt/sdjwt_dm_v2_suite.dart
+++ b/lib/src/credentials/sdjwt/sdjwt_dm_v2_suite.dart
@@ -228,17 +228,25 @@ class _DidSignerAdapter implements Signer {
   }
 }
 
+/// A [VcDataModelV2] backed by an SD-JWT credential structure.
+///
+/// Represents a Verifiable Credential in the W3C Data Model v2 format
+/// issued and managed as a Selective Disclosure JWT (SD-JWT).
 class SdJwtDataModelV2 extends VcDataModelV2
     implements ParsedVerifiableCredential<String> {
+  /// The underlying [SdJwt] object representing the signed credential.
   final SdJwt sdJwt;
 
+  /// Creates an [SdJwtDataModelV2] from a parsed [SdJwt] object.
   SdJwtDataModelV2.fromSdJwt(this.sdJwt)
       : super.clone(VcDataModelV2.fromJson(sdJwt.claims));
 
   @override
   String get serialized => sdJwt.serialized;
 
+  /// Returns the header section of the SD-JWT.
   Map<String, dynamic> get header => sdJwt.header;
 
+  /// Returns the set of selective disclosure claims (disclosures).
   Set<Disclosure> get disclosures => Set.unmodifiable(sdJwt.disclosures);
 }

--- a/lib/src/credentials/suites/universal_parser.dart
+++ b/lib/src/credentials/suites/universal_parser.dart
@@ -4,7 +4,10 @@ import '../models/parsed_vc.dart';
 import '../models/verifiable_credential.dart';
 import 'vc_suites.dart';
 
-/// Entry point to all supported VC parsers
+/// Entry point to all supported Verifiable Credential (VC) parsers.
+///
+/// Attempts to automatically detect and parse the input [rawData]
+/// using the available VC suites registered in [VcSuites].
 final class UniversalParser {
   /// Returns a [VerifiableCredential] instance.
   ///

--- a/lib/src/credentials/suites/universal_verifier.dart
+++ b/lib/src/credentials/suites/universal_verifier.dart
@@ -4,10 +4,19 @@ import '../verification/vc_expiry_verifier.dart';
 import '../verification/vc_integrity_verifier.dart';
 import '../verification/vc_verifier.dart';
 
-/// Allows verification of any supported VC encodings
+/// Allows verification of any supported Verifiable Credential (VC) encodings.
+///
+/// Combines a default set of verifiers (like expiry and integrity checks)
+/// and optional custom verifiers.
 final class UniversalVerifier {
+  /// List of custom verifiers provided during construction.
   final List<VcVerifier> customVerifiers;
 
+  /// Default verifiers always run during verification.
+  ///
+  /// Includes:
+  /// - [VcExpiryVerifier]: Validates the credential's expiration time.
+  /// - [VcIntegrityVerifier]: Validates the cryptographic integrity of the credential.
   static final List<VcVerifier> defaultVerifiers = List.unmodifiable(
     <VcVerifier>[
       VcExpiryVerifier(),
@@ -15,10 +24,18 @@ final class UniversalVerifier {
     ],
   );
 
+  /// Creates a [UniversalVerifier].
+  ///
+  /// Optionally accepts a list of [customVerifiers] to run after the defaults.
   UniversalVerifier({
     List<VcVerifier>? customVerifiers,
   }) : customVerifiers = customVerifiers ?? [];
 
+  /// Verifies the provided [data] using both default and custom verifiers.
+  ///
+  /// Aggregates all errors and warnings found during verification.
+  ///
+  /// Returns a [VerificationResult] summarizing the findings.
   Future<VerificationResult> verify(ParsedVerifiableCredential data) async {
     final errors = <String>[];
     final warnings = <String>[];

--- a/lib/src/credentials/suites/vc_suite.dart
+++ b/lib/src/credentials/suites/vc_suite.dart
@@ -25,5 +25,6 @@ abstract interface class VerifiableCredentialSuite<
   Future<bool> verifyIntegrity(ParsedVC input,
       {DateTime Function() getNow = DateTime.now});
 
+  /// Presents the [input] credential in its serialized form.
   dynamic present(ParsedVC input);
 }

--- a/lib/src/credentials/verification/vc_expiry_verifier.dart
+++ b/lib/src/credentials/verification/vc_expiry_verifier.dart
@@ -2,13 +2,25 @@ import '../../types.dart';
 import '../models/parsed_vc.dart';
 import 'vc_verifier.dart';
 
+/// Verifier that checks the validity period of a Verifiable Credential (VC).
+///
+/// It verifies whether the current time falls within the credential's
+/// `validFrom` and `validUntil` date range.
 class VcExpiryVerifier implements VcVerifier {
   final DateTime Function() _getNow;
 
+  /// Creates a [VcExpiryVerifier].
+  ///
+  /// Optionally accepts a [getNow] function to provide the current time,
+  /// useful for testing or custom time validation scenarios.
   VcExpiryVerifier({
     DateTime Function() getNow = DateTime.now,
   }) : _getNow = getNow;
 
+  /// Verifies that the [data] credential is currently valid based on its
+  /// `validFrom` and `validUntil` timestamps.
+  ///
+  /// Returns a [VerificationResult] indicating validity or listing expiration errors.
   @override
   Future<VerificationResult> verify(ParsedVerifiableCredential data) {
     var now = _getNow();

--- a/lib/src/credentials/verification/vc_integrity_verifier.dart
+++ b/lib/src/credentials/verification/vc_integrity_verifier.dart
@@ -4,7 +4,15 @@ import '../models/parsed_vc.dart';
 import '../suites/vc_suites.dart';
 import 'vc_verifier.dart';
 
+/// Verifier that checks the cryptographic integrity of a Verifiable Credential (VC).
+///
+/// It delegates the integrity verification to the appropriate VC suite
+/// based on the input credentials.
 class VcIntegrityVerifier implements VcVerifier {
+  /// Verifies the signature and cryptographic integrity of the [data] credential.
+  ///
+  /// Returns a [VerificationResult] indicating success or reporting a failed
+  /// integrity verification error.
   @override
   Future<VerificationResult> verify(ParsedVerifiableCredential data) async {
     final vcSuite = VcSuites.getVcSuite(data);

--- a/lib/src/credentials/verification/vc_verifier.dart
+++ b/lib/src/credentials/verification/vc_verifier.dart
@@ -1,6 +1,11 @@
 import '../../types.dart';
 import '../models/parsed_vc.dart';
 
+/// Interface for verifying Verifiable Credentials (VCs).
 abstract interface class VcVerifier {
+  /// Verifies the given [vc] credential and returns a [VerificationResult].
+  ///
+  /// Implementations should validate specific aspects of the credential
+  /// (e.g., expiration, proof signature) and report findings.
   Future<VerificationResult> verify(ParsedVerifiableCredential vc);
 }


### PR DESCRIPTION
add missing public api members docs for

/lib/src/credentials/jwt
/lib/src/credentials/linked_data
/lib/src/credentials/sdjwt
/lib/src/credentials/suites
and

/lib/src/credentials/parsers
/lib/src/credentials/proof
/lib/src/credentials/verification