### PR TITLE
fix: dependency version conflict

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,7 +10,6 @@ analyzer:
     lines_longer_than_80_chars: ignore
     avoid_print: error
     inference_failure_on_untyped_parameter: ignore
-    strict_top_level_inference: ignore
     avoid_dynamic_calls: ignore
     invalid_assignment: ignore
     argument_type_not_assignable: ignore

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dev_dependencies:
   aws_kms_api: ^2.0.0
   aws_signature_v4: ^0.6.4
   coverage: ^1.11.1
-  dart_flutter_team_lints: ^3.5.1
+  dart_flutter_team_lints: ^3.2.1
   jwt_decoder: ^2.0.1
   melos: ^6.3.2
   shared_aws_api: ^2.0.2


### PR DESCRIPTION
SSI should work with Dart version `3.6.0`, but dependency `dart_flutter_team_lints` latests versions requires at least version `3.7.0` 