### PR TITLE
fix: Remove DidDocument as a param for DidSigner

### DIFF
--- a/example/code_snippets/credentials/did/did_signer.dart
+++ b/example/code_snippets/credentials/did/did_signer.dart
@@ -9,7 +9,7 @@ Future<DidSigner> initSigner(Uint8List seed) async {
   final doc = DidKey.generateDocument(key.publicKey);
 
   final signer = DidSigner(
-    didDocument: doc,
+    did: doc.id,
     didKeyId: doc.verificationMethod[0].id,
     keyPair: key,
     signatureScheme: SignatureScheme.ecdsa_secp256k1_sha256,

--- a/lib/src/did/did_signer.dart
+++ b/lib/src/did/did_signer.dart
@@ -37,9 +37,6 @@ class DidSigner {
   /// Returns the DID identifier from the DID document.
   String get did => _did;
 
-  /// Returns the public key from the key pair.
-  PublicKey get publicKey => _keyPair.publicKey;
-
   /// The identifier of the key inside the DID document
   String get keyId => _didKeyId;
 

--- a/lib/src/did/did_signer.dart
+++ b/lib/src/did/did_signer.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 import '../key_pair/key_pair.dart';
 import '../key_pair/public_key.dart';
 import '../types.dart';
-import 'did_document/index.dart';
 
 /// A signer that uses a key pair associated with a DID document to sign data.
 class DidSigner {
@@ -14,10 +13,10 @@ class DidSigner {
   final SignatureScheme signatureScheme;
 
   /// The DID document containing the key information.
-  final DidDocument _didDocument;
+  final String _did;
 
   /// The identifier of the key inside the DID document.
-  final String didKeyId;
+  final String _didKeyId;
 
   /// Creates a new [DidSigner] instance.
   ///
@@ -27,21 +26,22 @@ class DidSigner {
   /// [signatureScheme] - The signature scheme to use for signing.
   // TODO(FTL-20741) validations, eg. keyId in doc, signature scheme supported, etc.
   DidSigner({
-    required DidDocument didDocument,
-    required this.didKeyId,
+    required String did,
+    required String didKeyId,
     required KeyPair keyPair,
     required this.signatureScheme,
-  })  : _keyPair = keyPair,
-        _didDocument = didDocument;
+  })  : _didKeyId = didKeyId,
+        _keyPair = keyPair,
+        _did = did;
 
   /// Returns the DID identifier from the DID document.
-  String get did => _didDocument.id;
+  String get did => _did;
 
   /// Returns the public key from the key pair.
   PublicKey get publicKey => _keyPair.publicKey;
 
   /// The identifier of the key inside the DID document
-  String get keyId => didKeyId;
+  String get keyId => _didKeyId;
 
   /// Signs the provided data using the key pair and signature scheme.
   Future<Uint8List> sign(Uint8List data) => _keyPair.sign(

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -9,7 +9,7 @@ Future<DidSigner> initSigner(Uint8List seed) async {
   final doc = DidKey.generateDocument(key.publicKey);
 
   final signer = DidSigner(
-    didDocument: doc,
+    did: doc.id,
     didKeyId: doc.verificationMethod[0].id,
     keyPair: key,
     signatureScheme: SignatureScheme.ecdsa_secp256k1_sha256,
@@ -22,7 +22,7 @@ Future<DidSigner> initEdSigner(Uint8List seed) async {
   final doc = DidKey.generateDocument(keyPair.publicKey);
 
   final signer = DidSigner(
-    didDocument: doc,
+    did: doc.id,
     didKeyId: doc.verificationMethod[0].id,
     keyPair: keyPair,
     signatureScheme: SignatureScheme.ed25519,
@@ -35,7 +35,7 @@ Future<DidSigner> initP256Signer(Uint8List seed) async {
   final doc = DidKey.generateDocument(keyPair.publicKey);
 
   final signer = DidSigner(
-    didDocument: doc,
+    did: doc.id,
     didKeyId: doc.verificationMethod[0].id,
     keyPair: keyPair,
     signatureScheme: SignatureScheme.ecdsa_p256_sha256,


### PR DESCRIPTION
This makes it simpler to use remote KeyPairs without having to fetch the publicKey to create the DidDocument to satisfy the interface, where the publicKey is not actually used by any of the existing signers.

Needs discussion: I have removed the `get publicKey` from DidSigner as well. Currently it hasn't been used anywhere, including tests and example code snippets. Are there scenarios where this getter would be helpful? cc: @cosminm-affnd @marco-a-affinidi @carlos-affinidi 

Adding this change to `v2` since it is a breaking change. 