### PR TITLE
feat: key-pair abstraction improved

### DIFF
--- a/lib/src/key_pair/key_pair.dart
+++ b/lib/src/key_pair/key_pair.dart
@@ -1,11 +1,13 @@
 import 'dart:typed_data';
+import 'package:meta/meta.dart';
 
 import '../exceptions/ssi_exception.dart';
+import '../exceptions/ssi_exception_type.dart';
 import '../types.dart';
 import 'public_key.dart';
 
 /// An abstract interface for cryptographic key pairs used for signing and verifying data.
-abstract interface class KeyPair {
+abstract class KeyPair {
   /// Wallet-internal identifier for this key pair.
   ///
   /// This is a local identifier used to reference the key within a wallet.
@@ -17,13 +19,19 @@ abstract interface class KeyPair {
   String get id;
 
   /// Returns a list of [SignatureScheme]s supported by this key pair.
-  List<SignatureScheme> get supportedSignatureSchemes;
+  List<SignatureScheme> get supportedSignatureSchemes =>
+      [defaultSignatureScheme];
 
   /// Returns the default signature scheme that is used if none is provided.
   SignatureScheme get defaultSignatureScheme;
 
   /// Returns the public key as as a touple with the type and bytes.
   PublicKey get publicKey;
+
+  ///
+  @protected
+  Future<Uint8List> internalSign(
+      Uint8List data, SignatureScheme signatureScheme);
 
   /// Signs the provided data using P-256 with SHA-256 hashing (ecdsa_p256_sha256).
   ///
@@ -34,10 +42,20 @@ abstract interface class KeyPair {
   /// as a [Uint8List].
   ///
   /// Throws [SsiException] if an unsupported [signatureScheme] is passed.
+  @nonVirtual
   Future<Uint8List> sign(
     Uint8List data, {
     SignatureScheme? signatureScheme,
-  });
+  }) {
+    signatureScheme =
+        _validateSignatureScheme(signatureScheme: signatureScheme);
+    return internalSign(data, signatureScheme);
+  }
+
+  ///
+  @protected
+  Future<bool> internalVerify(
+      Uint8List data, Uint8List signature, SignatureScheme signatureScheme);
 
   /// Verifies a signature for the given [data] using the public key and optionally a [signatureScheme].
   ///
@@ -48,11 +66,16 @@ abstract interface class KeyPair {
   /// Returns a [Future] that completes with `true` if the signature is valid, `false` otherwise.
   ///
   /// Throws [SsiException] if an unsupported [signatureScheme] is passed.
+  @nonVirtual
   Future<bool> verify(
     Uint8List data,
     Uint8List signature, {
     SignatureScheme? signatureScheme,
-  });
+  }) {
+    signatureScheme =
+        _validateSignatureScheme(signatureScheme: signatureScheme);
+    return internalVerify(data, signature, signatureScheme);
+  }
 
   /// Encrypts the provided data using the public key.
   Future<Uint8List> encrypt(Uint8List data, {Uint8List? publicKey});
@@ -66,4 +89,18 @@ abstract interface class KeyPair {
   ///
   /// Returns the computed shared secret as a [Uint8List].
   Future<Uint8List> computeEcdhSecret(Uint8List publicKey);
+
+  SignatureScheme _validateSignatureScheme({
+    SignatureScheme? signatureScheme,
+  }) {
+    signatureScheme ??= defaultSignatureScheme;
+    if (!supportedSignatureSchemes.contains(signatureScheme)) {
+      throw SsiException(
+        message:
+            'Unsupported signature scheme. Supported schemes: [${supportedSignatureSchemes.join(',')}].',
+        code: SsiExceptionType.unsupportedSignatureScheme.code,
+      );
+    }
+    return signatureScheme;
+  }
 }

--- a/lib/src/key_pair/p256_key_pair.dart
+++ b/lib/src/key_pair/p256_key_pair.dart
@@ -7,8 +7,6 @@ import 'package:elliptic/elliptic.dart' as ec;
 import 'package:pointycastle/api.dart' as pc;
 
 import '../digest_utils.dart';
-import '../exceptions/ssi_exception.dart';
-import '../exceptions/ssi_exception_type.dart';
 import '../types.dart';
 import '../utility.dart';
 import './_ecdh_utils.dart' as ecdh_utils;
@@ -22,7 +20,7 @@ import 'public_key.dart';
 /// This key pair supports signing and verifying data using the
 /// `ecdsa_p256_sha256` signature scheme. It also supports Elliptic Curve
 /// Diffie-Hellman (ECDH) key agreement.
-class P256KeyPair implements KeyPair {
+class P256KeyPair extends KeyPair {
   static final ec.EllipticCurve _p256 = ec.getP256();
   final ec.PrivateKey _privateKey;
   Uint8List? _publicKeyBytes;
@@ -71,18 +69,8 @@ class P256KeyPair implements KeyPair {
   }
 
   @override
-  Future<Uint8List> sign(
-    Uint8List data, {
-    SignatureScheme? signatureScheme,
-  }) async {
-    signatureScheme ??= SignatureScheme.ecdsa_p256_sha256;
-    if (signatureScheme != SignatureScheme.ecdsa_p256_sha256) {
-      throw SsiException(
-        message:
-            'Unsupported signature scheme. Currently only ecdsa_p256_sha256 is supported with p256',
-        code: SsiExceptionType.unsupportedSignatureScheme.code,
-      );
-    }
+  Future<Uint8List> internalSign(
+      Uint8List data, SignatureScheme signatureScheme) async {
     final digest = DigestUtils.getDigest(
       data,
       hashingAlgorithm: signatureScheme.hashingAlgorithm,
@@ -92,19 +80,8 @@ class P256KeyPair implements KeyPair {
   }
 
   @override
-  Future<bool> verify(
-    Uint8List data,
-    Uint8List signature, {
-    SignatureScheme? signatureScheme,
-  }) async {
-    signatureScheme ??= SignatureScheme.ecdsa_p256_sha256;
-    if (signatureScheme != SignatureScheme.ecdsa_p256_sha256) {
-      throw SsiException(
-        message:
-            'Unsupported signature scheme. Currently only ecdsa_p256_sha256 is supported with p256',
-        code: SsiExceptionType.unsupportedSignatureScheme.code,
-      );
-    }
+  Future<bool> internalVerify(Uint8List data, Uint8List signature,
+      SignatureScheme signatureScheme) async {
     final digest = DigestUtils.getDigest(
       data,
       hashingAlgorithm: signatureScheme.hashingAlgorithm,
@@ -113,10 +90,6 @@ class P256KeyPair implements KeyPair {
     var result = ecdsa.verify(_privateKey.publicKey, digest, signatureObj);
     return Future.value(result);
   }
-
-  @override
-  List<SignatureScheme> get supportedSignatureSchemes =>
-      [SignatureScheme.ecdsa_p256_sha256];
 
   @override
   SignatureScheme get defaultSignatureScheme =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   elliptic: ^0.3.11
   http: ^1.4.0
   json_ld_processor: ^1.0.4
+  meta: ^1.17.0
   pointycastle: ^4.0.0
   selective_disclosure_jwt: ^1.0.3
   x25519: ^0.1.1


### PR DESCRIPTION
Changes:
- meta added to improve `melos analyze` (for protected/final annotiations)
- KeyPair:
  -  => abstract class
  - verify / sign methods made final
  - corresponding methods added for override
  - SignatureScheme validation added
- children updated to reflect the above