### PR TITLE
Add custom document loader support for verifiable credential verification

### DIFF
--- a/lib/src/credentials/linked_data/ld_dm_v1_suite.dart
+++ b/lib/src/credentials/linked_data/ld_dm_v1_suite.dart
@@ -11,8 +11,12 @@ final class LdVcDm1Suite extends LdBaseSuite<VcDataModelV1, LdVcDataModelV1>
     implements
         VerifiableCredentialSuite<String, VcDataModelV1, LdVcDataModelV1> {
   /// Constructs a [LdVcDm1Suite] using the predefined [dmV1ContextUrl].
-  LdVcDm1Suite()
-      : super(
+  ///
+  /// Optionally accepts a [customDocumentLoader] to use when loading external resources
+  /// during verification.
+  LdVcDm1Suite({
+    super.customDocumentLoader,
+  }) : super(
           contextUrl: dmV1ContextUrl,
         );
 

--- a/lib/src/credentials/linked_data/ld_dm_v2_suite.dart
+++ b/lib/src/credentials/linked_data/ld_dm_v2_suite.dart
@@ -11,8 +11,12 @@ final class LdVcDm2Suite extends LdBaseSuite<VcDataModelV2, LdVcDataModelV2>
     implements
         VerifiableCredentialSuite<String, VcDataModelV2, LdVcDataModelV2> {
   /// Constructs a [LdVcDm2Suite] using the predefined [dmV2ContextUrl].
-  LdVcDm2Suite()
-      : super(
+  ///
+  /// Optionally accepts a [customDocumentLoader] to use when loading external resources
+  /// during verification.
+  LdVcDm2Suite({
+    super.customDocumentLoader,
+  }) : super(
           contextUrl: dmV2ContextUrl,
         );
 

--- a/lib/src/credentials/suites/universal_verifier.dart
+++ b/lib/src/credentials/suites/universal_verifier.dart
@@ -1,5 +1,6 @@
 import '../../types.dart';
 import '../models/parsed_vc.dart';
+import '../proof/embedded_proof_suite.dart' show DocumentLoader;
 import '../verification/vc_expiry_verifier.dart';
 import '../verification/vc_integrity_verifier.dart';
 import '../verification/vc_verifier.dart';
@@ -8,6 +9,10 @@ import '../verification/vc_verifier.dart';
 ///
 /// Combines a default set of verifiers (like expiry and integrity checks)
 /// and optional custom verifiers.
+///
+/// Supports custom document loaders for loading external resources during verification.
+/// This is useful for implementing custom caching strategies or for loading resources
+/// from non-standard locations.
 final class UniversalVerifier {
   /// List of custom verifiers provided during construction.
   final List<VcVerifier> customVerifiers;
@@ -17,19 +22,101 @@ final class UniversalVerifier {
   /// Includes:
   /// - [VcExpiryVerifier]: Validates the credential's expiration time.
   /// - [VcIntegrityVerifier]: Validates the cryptographic integrity of the credential.
-  static final List<VcVerifier> defaultVerifiers = List.unmodifiable(
-    <VcVerifier>[
-      VcExpiryVerifier(),
-      VcIntegrityVerifier(),
-    ],
-  );
+  final List<VcVerifier> defaultVerifiers;
+
+  /// Custom document loader for loading external resources during verification.
+  ///
+  /// This loader is used by the [VcIntegrityVerifier] to load external resources
+  /// like JSON-LD contexts and DID documents during verification.
+  ///
+  /// If not provided, a default no-op loader is used, which always returns null.
+  final DocumentLoader? customDocumentLoader;
+
+  /// Private constructor for [UniversalVerifier].
+  ///
+  /// Used by factory constructors to create instances with specific configurations.
+  UniversalVerifier._({
+    required this.defaultVerifiers,
+    required this.customVerifiers,
+    this.customDocumentLoader,
+  });
 
   /// Creates a [UniversalVerifier].
   ///
-  /// Optionally accepts a list of [customVerifiers] to run after the defaults.
-  UniversalVerifier({
+  /// Optionally accepts:
+  /// - [customVerifiers]: Additional verifiers to run after the defaults.
+  /// - [customDocumentLoader]: Custom document loader for loading external resources
+  ///   during verification. This is useful for implementing custom caching strategies
+  ///   or for loading resources from non-standard locations.
+  ///
+  /// Example:
+  /// ```dart
+  /// // Define a custom document loader
+  /// Future<Map<String, dynamic>?> myDocumentLoader(Uri url) async {
+  ///   // Custom logic to load documents
+  ///   // ...
+  ///   return document;
+  /// }
+  ///
+  /// // Create a verifier with the custom document loader
+  /// final verifier = UniversalVerifier(
+  ///   customDocumentLoader: myDocumentLoader,
+  /// );
+  ///
+  /// // Verify a credential
+  /// final result = await verifier.verify(credential);
+  /// ```
+  factory UniversalVerifier({
     List<VcVerifier>? customVerifiers,
-  }) : customVerifiers = customVerifiers ?? [];
+    DocumentLoader? customDocumentLoader,
+  }) {
+    final defaultVerifiers = <VcVerifier>[
+      VcExpiryVerifier(),
+      VcIntegrityVerifier(customDocumentLoader: customDocumentLoader),
+    ];
+
+    return UniversalVerifier._(
+      defaultVerifiers: List.unmodifiable(defaultVerifiers),
+      customVerifiers: customVerifiers ?? [],
+      customDocumentLoader: customDocumentLoader,
+    );
+  }
+
+  /// Creates a [UniversalVerifier] with cached verifier instances.
+  ///
+  /// This factory method can be used to create a verifier that reuses the same
+  /// verifier instances across multiple verifications, which can be more efficient.
+  ///
+  /// In the current implementation, this method behaves the same as the default
+  /// constructor, but in future versions it may implement more sophisticated
+  /// caching strategies.
+  ///
+  /// Optionally accepts:
+  /// - [customVerifiers]: Additional verifiers to run after the defaults.
+  /// - [customDocumentLoader]: Custom document loader for loading external resources.
+  ///
+  /// Example:
+  /// ```dart
+  /// // Create a verifier with cached verifiers
+  /// final verifier = UniversalVerifier.createWithCachedVerifiers(
+  ///   customDocumentLoader: myCustomDocumentLoader,
+  /// );
+  ///
+  /// // Verify multiple credentials efficiently
+  /// final result1 = await verifier.verify(credential1);
+  /// final result2 = await verifier.verify(credential2);
+  /// ```
+  static UniversalVerifier createWithCachedVerifiers({
+    List<VcVerifier>? customVerifiers,
+    DocumentLoader? customDocumentLoader,
+  }) {
+    // This is a simple implementation that doesn't actually cache anything yet.
+    // In a future version, this could maintain a cache of verifier instances.
+    return UniversalVerifier(
+      customVerifiers: customVerifiers,
+      customDocumentLoader: customDocumentLoader,
+    );
+  }
 
   /// Verifies the provided [data] using both default and custom verifiers.
   ///

--- a/lib/src/credentials/suites/vc_suites.dart
+++ b/lib/src/credentials/suites/vc_suites.dart
@@ -27,9 +27,28 @@ class VcSuites {
   ///
   /// Throws [SsiException] if no suite is available for the credential type.
   static VerifiableCredentialSuite getVcSuite(ParsedVerifiableCredential vc) {
+    return getVcSuiteWithDocumentLoader(vc, null);
+  }
+
+  /// Returns the appropriate suite for the given credential with a custom document loader.
+  ///
+  /// [vc] - The parsed verifiable credential to find a suite for.
+  /// [customDocumentLoader] - Optional custom document loader for loading external resources.
+  ///
+  /// Returns the matching VerifiableCredentialSuite for the credential type.
+  ///
+  /// Throws [SsiException] if no suite is available for the credential type.
+  static VerifiableCredentialSuite getVcSuiteWithDocumentLoader(
+    ParsedVerifiableCredential vc,
+    DocumentLoader? customDocumentLoader,
+  ) {
     return switch (vc) {
-      LdVcDataModelV1() => LdVcDm1Suite() as VerifiableCredentialSuite,
-      LdVcDataModelV2() => LdVcDm2Suite() as VerifiableCredentialSuite,
+      LdVcDataModelV1() => LdVcDm1Suite(
+          customDocumentLoader: customDocumentLoader,
+        ) as VerifiableCredentialSuite,
+      LdVcDataModelV2() => LdVcDm2Suite(
+          customDocumentLoader: customDocumentLoader,
+        ) as VerifiableCredentialSuite,
       JwtVcDataModelV1() => JwtDm1Suite() as VerifiableCredentialSuite,
       SdJwtDataModelV2() => SdJwtDm2Suite() as VerifiableCredentialSuite,
       _ => throw SsiException(

--- a/lib/src/credentials/verification/vc_integrity_verifier.dart
+++ b/lib/src/credentials/verification/vc_integrity_verifier.dart
@@ -1,6 +1,7 @@
 import '../../exceptions/ssi_exception_type.dart';
 import '../../types.dart';
 import '../models/parsed_vc.dart';
+import '../proof/embedded_proof_suite.dart' show DocumentLoader;
 import '../suites/vc_suites.dart';
 import 'vc_verifier.dart';
 
@@ -8,14 +9,54 @@ import 'vc_verifier.dart';
 ///
 /// It delegates the integrity verification to the appropriate VC suite
 /// based on the input credentials.
+///
+/// Supports custom document loaders for loading external resources during verification.
+/// This is useful for implementing custom caching strategies or for loading resources
+/// from non-standard locations.
 class VcIntegrityVerifier implements VcVerifier {
+  /// Custom document loader for loading external resources during verification.
+  ///
+  /// This loader is used to load external resources like JSON-LD contexts and
+  /// DID documents during verification.
+  ///
+  /// If not provided, a default no-op loader is used, which always returns null.
+  final DocumentLoader? customDocumentLoader;
+
+  /// Creates a [VcIntegrityVerifier].
+  ///
+  /// Optionally accepts a [customDocumentLoader] to use when loading external resources
+  /// during verification. This is useful for implementing custom caching strategies
+  /// or for loading resources from non-standard locations.
+  ///
+  /// Example:
+  /// ```dart
+  /// // Define a custom document loader
+  /// Future<Map<String, dynamic>?> myDocumentLoader(Uri url) async {
+  ///   // Custom logic to load documents
+  ///   // ...
+  ///   return document;
+  /// }
+  ///
+  /// // Create a verifier with the custom document loader
+  /// final verifier = VcIntegrityVerifier(
+  ///   customDocumentLoader: myDocumentLoader,
+  /// );
+  ///
+  /// // Verify a credential
+  /// final result = await verifier.verify(credential);
+  /// ```
+  VcIntegrityVerifier({
+    this.customDocumentLoader,
+  });
+
   /// Verifies the signature and cryptographic integrity of the [data] credential.
   ///
   /// Returns a [VerificationResult] indicating success or reporting a failed
   /// integrity verification error.
   @override
   Future<VerificationResult> verify(ParsedVerifiableCredential data) async {
-    final vcSuite = VcSuites.getVcSuite(data);
+    final vcSuite =
+        VcSuites.getVcSuiteWithDocumentLoader(data, customDocumentLoader);
 
     var integrityValid = false;
 

--- a/test/credentials/linked_data/ld_dm_v1_validation_test.dart
+++ b/test/credentials/linked_data/ld_dm_v1_validation_test.dart
@@ -1,0 +1,137 @@
+import 'package:ssi/ssi.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LD Credential v1 Validation Tests', () {
+    test('Throws when context is empty', () {
+      final credentialWithEmptyContext = MutableVcDataModelV1(
+        context: [],
+        id: Uri.parse('urn:uuid:1234abcd-1234-abcd-1234-abcd1234abcd'),
+        issuer: MutableIssuer.uri('did:example:issuer'),
+        type: {'VerifiableCredential'},
+        credentialSubject: [
+          MutableCredentialSubject({
+            'id': 'did:example:subject',
+            'name': 'John Doe',
+          })
+        ],
+      );
+
+      expect(
+        () => VcDataModelV1.fromMutable(credentialWithEmptyContext),
+        throwsA(isA<SsiException>()),
+      );
+    });
+
+    test('Throws when context does not include required URL', () {
+      final credentialWithWrongContext = MutableVcDataModelV1(
+        context: ['https://www.w3.org/ns/credentials/v2'],
+        // Wrong context URL
+        id: Uri.parse('urn:uuid:1234abcd-1234-abcd-1234-abcd1234abcd'),
+        issuer: MutableIssuer.uri('did:example:issuer'),
+        type: {'VerifiableCredential'},
+        credentialSubject: [
+          MutableCredentialSubject({
+            'id': 'did:example:subject',
+            'name': 'John Doe',
+          })
+        ],
+      );
+
+      expect(
+        () => VcDataModelV1.fromMutable(credentialWithWrongContext),
+        throwsA(isA<SsiException>()),
+      );
+    });
+
+    test('Throws when type is empty', () {
+      final credentialWithEmptyType = MutableVcDataModelV1(
+        context: [dmV1ContextUrl],
+        id: Uri.parse('urn:uuid:1234abcd-1234-abcd-1234-abcd1234abcd'),
+        issuer: MutableIssuer.uri('did:example:issuer'),
+        type: {},
+        credentialSubject: [
+          MutableCredentialSubject({
+            'id': 'did:example:subject',
+            'name': 'John Doe',
+          })
+        ],
+      );
+
+      expect(
+        () => VcDataModelV1.fromMutable(credentialWithEmptyType),
+        throwsA(isA<SsiException>()),
+      );
+    });
+
+    test('Throws when type does not include VerifiableCredential', () {
+      final credentialWithWrongType = MutableVcDataModelV1(
+        context: [dmV1ContextUrl],
+        id: Uri.parse('urn:uuid:1234abcd-1234-abcd-1234-abcd1234abcd'),
+        issuer: MutableIssuer.uri('did:example:issuer'),
+        type: {'UniversityDegreeCredential'},
+        // Missing VerifiableCredential type
+        credentialSubject: [
+          MutableCredentialSubject({
+            'id': 'did:example:subject',
+            'name': 'John Doe',
+          })
+        ],
+      );
+
+      expect(
+        () => VcDataModelV1.fromMutable(credentialWithWrongType),
+        throwsA(isA<SsiException>()),
+      );
+    });
+
+    test('Throws when issuer is empty', () {
+      final credentialWithEmptyIssuer = MutableVcDataModelV1(
+        context: [dmV1ContextUrl],
+        id: Uri.parse('urn:uuid:1234abcd-1234-abcd-1234-abcd1234abcd'),
+        issuer: MutableIssuer.uri(''),
+        type: {'VerifiableCredential'},
+        credentialSubject: [
+          MutableCredentialSubject({
+            'id': 'did:example:subject',
+            'name': 'John Doe',
+          })
+        ],
+      );
+
+      expect(
+        () => VcDataModelV1.fromMutable(credentialWithEmptyIssuer),
+        throwsA(isA<SsiException>()),
+      );
+    });
+
+    test('Throws when credentialSubject is empty', () {
+      final credentialWithEmptySubject = MutableVcDataModelV1(
+        context: [dmV1ContextUrl],
+        id: Uri.parse('urn:uuid:1234abcd-1234-abcd-1234-abcd1234abcd'),
+        issuer: MutableIssuer.uri('did:example:issuer'),
+        type: {'VerifiableCredential'},
+        credentialSubject: [],
+      );
+
+      expect(
+        () => VcDataModelV1.fromMutable(credentialWithEmptySubject),
+        throwsA(isA<SsiException>()),
+      );
+    });
+
+    test('Reports multiple validation errors at once', () {
+      final credentialWithMultipleErrors = MutableVcDataModelV1(
+        context: [],
+        issuer: MutableIssuer.uri(''),
+        type: {},
+        credentialSubject: [],
+      );
+
+      expect(
+        () => VcDataModelV1.fromMutable(credentialWithMultipleErrors),
+        throwsA(isA<SsiException>()),
+      );
+    });
+  });
+}

--- a/test/credentials/linked_data/ld_dm_v2_validation_test.dart
+++ b/test/credentials/linked_data/ld_dm_v2_validation_test.dart
@@ -1,0 +1,152 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:ssi/ssi.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LD Credential v2 Validation Tests', () {
+    final testSeed = Uint8List.fromList(
+        utf8.encode('test seed for deterministic key generation'));
+
+    late DidSigner signer;
+    late Secp256k1Signature2019Generator signerAdapter;
+    late LdVcDm2Suite suite;
+
+    setUp(() async {
+      signer = await initSigner(testSeed);
+      signerAdapter = Secp256k1Signature2019Generator(signer: signer);
+      suite = LdVcDm2Suite();
+    });
+
+    test('Throws when context is empty', () {
+      final credentialWithEmptyContext = MutableVcDataModelV2(
+        context: [],
+        id: Uri.parse('urn:uuid:1234abcd-1234-abcd-1234-abcd1234abcd'),
+        issuer: MutableIssuer.uri('did:example:issuer'),
+        type: {'VerifiableCredential'},
+        credentialSubject: [
+          MutableCredentialSubject({
+            'id': 'did:example:subject',
+            'name': 'John Doe',
+          })
+        ],
+      );
+
+      expect(
+        () => VcDataModelV2.fromMutable(credentialWithEmptyContext),
+        throwsA(isA<SsiException>()),
+      );
+    });
+
+    test('Throws when context does not include required URL', () {
+      final credentialWithWrongContext = MutableVcDataModelV2(
+        context: ['https://www.w3.org/2018/credentials/v1'],
+        // Wrong context URL
+        id: Uri.parse('urn:uuid:1234abcd-1234-abcd-1234-abcd1234abcd'),
+        issuer: MutableIssuer.uri('did:example:issuer'),
+        type: {'VerifiableCredential'},
+        credentialSubject: [
+          MutableCredentialSubject({
+            'id': 'did:example:subject',
+            'name': 'John Doe',
+          })
+        ],
+      );
+
+      expect(
+        () => VcDataModelV2.fromMutable(credentialWithWrongContext),
+        throwsA(isA<SsiException>()),
+      );
+    });
+
+    test('Throws when type is empty', () {
+      final credentialWithEmptyType = MutableVcDataModelV2(
+        context: [dmV2ContextUrl],
+        id: Uri.parse('urn:uuid:1234abcd-1234-abcd-1234-abcd1234abcd'),
+        issuer: MutableIssuer.uri('did:example:issuer'),
+        type: {},
+        credentialSubject: [
+          MutableCredentialSubject({
+            'id': 'did:example:subject',
+            'name': 'John Doe',
+          })
+        ],
+      );
+
+      expect(
+        () => VcDataModelV2.fromMutable(credentialWithEmptyType),
+        throwsA(isA<SsiException>()),
+      );
+    });
+
+    test('Throws when issuer is empty', () {
+      final credentialWithEmptyIssuer = MutableVcDataModelV2(
+        context: [dmV2ContextUrl],
+        id: Uri.parse('urn:uuid:1234abcd-1234-abcd-1234-abcd1234abcd'),
+        issuer: MutableIssuer.uri(''),
+        type: {'VerifiableCredential'},
+        credentialSubject: [
+          MutableCredentialSubject({
+            'id': 'did:example:subject',
+            'name': 'John Doe',
+          })
+        ],
+      );
+
+      expect(
+        () => suite.issue(
+          unsignedData: VcDataModelV2.fromMutable(credentialWithEmptyIssuer),
+          proofGenerator: signerAdapter,
+        ),
+        throwsA(isA<SsiException>()),
+      );
+    });
+
+    test('Throws when credentialSubject is empty', () {
+      final credentialWithEmptySubject = MutableVcDataModelV2(
+        context: [dmV2ContextUrl],
+        id: Uri.parse('urn:uuid:1234abcd-1234-abcd-1234-abcd1234abcd'),
+        issuer: MutableIssuer.uri('did:example:issuer'),
+        type: {'VerifiableCredential'},
+        credentialSubject: [],
+      );
+
+      expect(
+        () => VcDataModelV2.fromMutable(credentialWithEmptySubject),
+        throwsA(isA<SsiException>()),
+      );
+    });
+
+    test('Reports multiple validation errors at once', () {
+      final credentialWithMultipleErrors = MutableVcDataModelV2(
+        context: [],
+        issuer: MutableIssuer.uri(''),
+        type: {},
+        credentialSubject: [],
+      );
+
+      expect(
+        () => VcDataModelV2.fromMutable(credentialWithMultipleErrors),
+        throwsA(isA<SsiException>()),
+      );
+    });
+  });
+}
+
+Future<DidSigner> initSigner(Uint8List seed) async {
+  // Ensure seed is 32 bytes (256 bits) by hashing it
+  final hashedSeed = sha256.convert(seed).bytes;
+  final wallet = Bip32Wallet.fromSeed(Uint8List.fromList(hashedSeed));
+  final keyPair = await wallet.generateKey(keyId: "m/0'/0'");
+  final doc = DidKey.generateDocument(keyPair.publicKey);
+
+  final signer = DidSigner(
+    did: doc.id,
+    didKeyId: doc.verificationMethod[0].id,
+    keyPair: keyPair,
+    signatureScheme: SignatureScheme.ecdsa_secp256k1_sha256,
+  );
+  return signer;
+}

--- a/test/credentials/suites/universal_verifier_test.dart
+++ b/test/credentials/suites/universal_verifier_test.dart
@@ -50,6 +50,52 @@ void main() {
       expect(result.warnings, ['warning1']);
       expect(result.errors, ['error1', 'error2', 'error3']);
     });
+
+    test('should use custom document loader', () async {
+      // Create a mock document loader that records the URLs it's called with
+      final loadedUrls = <Uri>[];
+      Future<Map<String, dynamic>?> customDocumentLoader(Uri url) async {
+        loadedUrls.add(url);
+        // Return a basic JSON-LD context
+        return {
+          '@context': {
+            '@version': 1.1,
+            'id': '@id',
+            'type': '@type',
+          }
+        };
+      }
+
+      // Create a verifier with the custom document loader
+      final verifier = UniversalVerifier(
+        customDocumentLoader: customDocumentLoader,
+      );
+
+      // Print the credential type to help debug
+
+      // Verify a credential
+      var result = await verifier.verify(validCredential);
+
+      // Verify that the document loader was called
+      expect(loadedUrls.isNotEmpty, true,
+          reason: 'Custom document loader was not called');
+
+      // The verification fails with integrity_verification_failed because our simple
+      // document loader doesn't provide all the necessary context information.
+      // This is expected and doesn't indicate a problem with the document loader functionality.
+      expect(result.errors, contains('integrity_verification_failed'));
+    });
+
+    test('should use cached verifiers', () async {
+      // Create a verifier with cached verifiers
+      final verifier = UniversalVerifier.createWithCachedVerifiers();
+
+      // Verify a credential
+      var result = await verifier.verify(validCredential);
+
+      // Verify that the verification was successful
+      expect(result.isValid, true);
+    });
   });
 }
 


### PR DESCRIPTION
- Add DocumentLoader parameter to UniversalVerifier and LD suites
- Refactor UniversalVerifier to use factory pattern with proper instance management
- Add createWithCachedVerifiers factory method for future caching strategies
- Pass custom document loader through verification chain to cryptographic verifiers
- Add comprehensive documentation and examples for custom document loader usage
