### PR TITLE
fix: jcs proof context

### DIFF
--- a/lib/src/credentials/proof/base_jcs_generator.dart
+++ b/lib/src/credentials/proof/base_jcs_generator.dart
@@ -60,10 +60,13 @@ abstract class BaseJcsGenerator extends EmbeddedProofSuiteCreateOptions
       domain: domain,
     );
 
+    final additionalProperties = <String, dynamic>{};
+
     // Set proof context to document context if present
     final documentContext = document['@context'];
     if (documentContext != null) {
       proof['@context'] = documentContext;
+      additionalProperties['@context'] = documentContext;
     }
 
     // Validate proof configuration structure
@@ -80,10 +83,6 @@ abstract class BaseJcsGenerator extends EmbeddedProofSuiteCreateOptions
     );
     final signature = await computeSignature(hash, signer);
 
-    // Remove context and add signature to proof
-    proof.remove('@context');
-    proof['proofValue'] = signature;
-
     return EmbeddedProof(
       type: JcsUtils.dataIntegrityType,
       cryptosuite: cryptosuite,
@@ -94,6 +93,7 @@ abstract class BaseJcsGenerator extends EmbeddedProofSuiteCreateOptions
       expires: expires,
       challenge: challenge,
       domain: domain,
+      additionalProperties: additionalProperties,
     );
   }
 

--- a/test/credentials/proof/data_integrity_ecdsa_test.dart
+++ b/test/credentials/proof/data_integrity_ecdsa_test.dart
@@ -263,7 +263,6 @@ void main() async {
       final credentialJson = issuedCredential.toJson();
       final proof = credentialJson['proof'] as Map<String, dynamic>;
 
-      // The proof should NOT have @context in the final form (it's removed after signing)
       expect(proof.containsKey('@context'), true);
 
       final proofVerifier =

--- a/test/credentials/proof/data_integrity_ecdsa_test.dart
+++ b/test/credentials/proof/data_integrity_ecdsa_test.dart
@@ -264,7 +264,7 @@ void main() async {
       final proof = credentialJson['proof'] as Map<String, dynamic>;
 
       // The proof should NOT have @context in the final form (it's removed after signing)
-      expect(proof.containsKey('@context'), false);
+      expect(proof.containsKey('@context'), true);
 
       final proofVerifier =
           DataIntegrityEcdsaJcsVerifier(verifierDid: signer.did);

--- a/test/credentials/proof/data_integrity_eddsa_test.dart
+++ b/test/credentials/proof/data_integrity_eddsa_test.dart
@@ -209,7 +209,6 @@ void main() async {
       final credentialJson = issuedCredential.toJson();
       final proof = credentialJson['proof'] as Map<String, dynamic>;
 
-      // The proof should NOT have @context in the final form (it's removed after signing)
       expect(proof.containsKey('@context'), true);
 
       final proofVerifier =

--- a/test/credentials/proof/data_integrity_eddsa_test.dart
+++ b/test/credentials/proof/data_integrity_eddsa_test.dart
@@ -210,7 +210,7 @@ void main() async {
       final proof = credentialJson['proof'] as Map<String, dynamic>;
 
       // The proof should NOT have @context in the final form (it's removed after signing)
-      expect(proof.containsKey('@context'), false);
+      expect(proof.containsKey('@context'), true);
 
       final proofVerifier =
           DataIntegrityEddsaJcsVerifier(verifierDid: edSigner.did);


### PR DESCRIPTION
During cross testing, it was found that `@context` was not set to proof:
<img width="1245" height="851" alt="Screenshot 2025-07-29 at 21 33 47" src="https://github.com/user-attachments/assets/eaee2194-f21a-429d-a319-8a1d559bdcc7" />

Also, in the [spec](https://www.w3.org/TR/vc-di-eddsa/#example-signed-credential-0) examples context is available in proof
<img width="869" height="425" alt="image" src="https://github.com/user-attachments/assets/27a3eae7-81aa-47e2-a849-c064b91f22ec" />

