### PR TITLE
fix: improve secp256k1 jws verifier to support DER encoded signatures

### DIFF
--- a/lib/src/credentials/proof/base_secp256k1_verifier.dart
+++ b/lib/src/credentials/proof/base_secp256k1_verifier.dart
@@ -310,7 +310,7 @@ Future<bool> verifyJws(
     }
   }
 
-  // Some libraries produce r||s with variable size (?) — as last resort, if signature is 64 bytes try split
+  // If signature is 64 bytes, verification was already attempted above; if it fails, return false.
   if (signature.length == 64) {
     // already tried as-is above, so failing here means verification failed
     return false;


### PR DESCRIPTION
After some internal validation tests against Digital Bazaar credentials we found out the jws signatures created with digital bazaar are DER encoded. This resulted in invalid signature errors as our SSI repo does not support this encoding. This PR adds that support.

This pull request refactors and enhances the JWS verification logic in `base_secp256k1_verifier.dart`. The new implementation supports both compact and detached JWS formats, enforces stricter header and payload validation, improves signature format compatibility, and adds error handling. These changes make the verifier more compliant with standards and resilient to edge cases.

**JWS parsing and validation improvements:**

* Added support for both compact (header.payload.signature) and RFC7797 detached (header..signature) JWS formats, with clear error handling for invalid formats.
* Enforced stricter validation of the JWS header, including checks for the `alg` field and correct handling of the `b64` and `crit` parameters as per RFC7797.
* Improved `kid`/verification method matching logic to handle fragments and alternate encodings, reducing risk of mismatches.

**Signature format compatibility:**

* Added logic to handle both raw (P1363 r||s) and DER-encoded ECDSA signatures; includes a helper for converting DER to P1363 format for verification.
* Enhanced error handling and fallback mechanisms to try multiple signature formats, improving interoperability with different libraries.