### PR TITLE
fix: implement one-to-one key to verification method mapping for mult…

### DIFF
--- a/lib/src/did/did_manager/did_peer_manager.dart
+++ b/lib/src/did/did_manager/did_peer_manager.dart
@@ -33,10 +33,7 @@ class DidPeerManager extends DidManager {
     required PublicKey publicKey,
     required Set<VerificationRelationship> relationships,
   }) async {
-    final createdRelationships = <VerificationRelationship, String>{};
-    String? primaryVmId;
-
-    // If no relationships are specified, create one VM not attached to any purpose.
+    // ── Empty relationships: one unattached VM ──
     if (relationships.isEmpty) {
       final vmId = await buildVerificationMethodId(publicKey);
       await store.setMapping(vmId, walletKeyId);
@@ -46,8 +43,27 @@ class DidPeerManager extends DidManager {
       );
     }
 
-    // Define a fixed order for processing relationships to ensure consistent
-    // DID generation, as the order of elements in a did:peer:2 DID is significant.
+    final createdRelationships = <VerificationRelationship, String>{};
+
+    // Skip primary VM only when sole relationship is keyAgreement on ed25519.
+    final needsPrimaryVm = !(relationships.length == 1 &&
+        relationships.first == VerificationRelationship.keyAgreement &&
+        publicKey.type == KeyType.ed25519);
+
+    // Build PRIMARY VM id once.
+    String? primaryVmId;
+    if (needsPrimaryVm) {
+      primaryVmId = await buildVerificationMethodId(publicKey);
+      await addVerificationMethodFromPublicKey(
+        publicKey,
+        verificationMethodId: primaryVmId,
+      );
+    }
+
+    // Build DERIVED X25519 VM lazily.
+    String? derivedVmId;
+
+    // Fixed processing order — significant for did:peer:2 DID string generation.
     const processingOrder = [
       VerificationRelationship.authentication,
       VerificationRelationship.keyAgreement,
@@ -56,51 +72,44 @@ class DidPeerManager extends DidManager {
       VerificationRelationship.assertionMethod,
     ];
 
-    final orderedRelationships =
-        processingOrder.where((r) => relationships.contains(r));
-
-    for (final relationship in orderedRelationships) {
-      final String vmId;
-      // Special handling for keyAgreement with Ed25519 keys
+    for (final relationship
+        in processingOrder.where((r) => relationships.contains(r))) {
       if (relationship == VerificationRelationship.keyAgreement &&
           publicKey.type == KeyType.ed25519) {
-        final x25519PublicKeyBytes =
-            ed25519PublicToX25519Public(publicKey.bytes);
-        final keyAgreementPublicKey =
-            PublicKey(publicKey.id, x25519PublicKeyBytes, KeyType.x25519);
-        vmId = await buildVerificationMethodId(keyAgreementPublicKey);
+        if (derivedVmId == null) {
+          final x25519Bytes = ed25519PublicToX25519Public(publicKey.bytes);
+          final x25519Key =
+              PublicKey(publicKey.id, x25519Bytes, KeyType.x25519);
+          derivedVmId = await buildVerificationMethodId(x25519Key);
+          await addVerificationMethodFromPublicKey(
+            x25519Key,
+            verificationMethodId: derivedVmId,
+          );
+        }
+        await addKeyAgreement(derivedVmId);
+        createdRelationships[relationship] = derivedVmId;
       } else {
-        vmId = await buildVerificationMethodId(publicKey);
+        switch (relationship) {
+          case VerificationRelationship.authentication:
+            await addAuthentication(primaryVmId!);
+          case VerificationRelationship.assertionMethod:
+            await addAssertionMethod(primaryVmId!);
+          case VerificationRelationship.capabilityInvocation:
+            await addCapabilityInvocation(primaryVmId!);
+          case VerificationRelationship.capabilityDelegation:
+            await addCapabilityDelegation(primaryVmId!);
+          case VerificationRelationship.keyAgreement:
+            await addKeyAgreement(primaryVmId!);
+        }
+        createdRelationships[relationship] = primaryVmId;
       }
-
-      await addVerificationMethodFromPublicKey(
-        publicKey,
-        verificationMethodId: vmId,
-      );
-      primaryVmId ??= vmId;
-
-      switch (relationship) {
-        case VerificationRelationship.authentication:
-          await addAuthentication(vmId);
-          break;
-        case VerificationRelationship.assertionMethod:
-          await addAssertionMethod(vmId);
-          break;
-        case VerificationRelationship.capabilityInvocation:
-          await addCapabilityInvocation(vmId);
-          break;
-        case VerificationRelationship.capabilityDelegation:
-          await addCapabilityDelegation(vmId);
-          break;
-        case VerificationRelationship.keyAgreement:
-          await addKeyAgreement(vmId);
-          break;
-      }
-      createdRelationships[relationship] = vmId;
     }
 
+    // At least one VM must have been created: either the primary or the derived.
+    assert(primaryVmId != null || derivedVmId != null);
+
     return AddVerificationMethodResult(
-      verificationMethodId: primaryVmId!,
+      verificationMethodId: primaryVmId ?? derivedVmId!,
       relationships: createdRelationships,
     );
   }
@@ -122,7 +131,16 @@ class DidPeerManager extends DidManager {
     // Get all verification method IDs in their creation order.
     final uniqueVmIds = await store.verificationMethodIds;
 
-    // Create a list of public keys for each unique verification method.
+    // Create a list of public keys for each unique verification method,
+    // converting Ed25519 to X25519 for keyAgreement VMs.
+    //
+    // NOTE: `wallet.getPublicKey()` always returns the **original** key type
+    // stored in the wallet (e.g. ed25519), even for VMs that were created with
+    // a derived X25519 public key in `internalAddVerificationMethod`. For
+    // derived keyAgreement VMs this means the conversion below re-derives the
+    // X25519 key — the result is identical because `ed25519PublicToX25519Public`
+    // is a deterministic pure function. This is intentional and ensures the DID
+    // document always contains the correct X25519 multibase encoding.
     final verificationMethodsPubKeys = <PublicKey>[];
     for (final vmId in uniqueVmIds) {
       final walletKeyId = await getWalletKeyId(vmId);

--- a/lib/src/did/did_manager/did_web_manager.dart
+++ b/lib/src/did/did_manager/did_web_manager.dart
@@ -75,7 +75,15 @@ class DidWebManager extends DidManager {
       );
     }
 
-    // Build public keys list. Converting Ed25519 to X25519 for keyAgreement VMs
+    // Build public keys list, converting Ed25519 to X25519 for keyAgreement VMs.
+    //
+    // NOTE: `wallet.getPublicKey()` always returns the **original** key type
+    // stored in the wallet (e.g. ed25519), even for VMs that were created with
+    // a derived X25519 public key in `internalAddVerificationMethod`. For
+    // derived keyAgreement VMs this means the conversion below re-derives the
+    // X25519 key — the result is identical because `ed25519PublicToX25519Public`
+    // is a deterministic pure function. This is intentional and ensures the DID
+    // document always contains the correct X25519 multibase encoding.
     final verificationMethodPublicKeys = <PublicKey>[];
     for (final vmId in uniqueVmIds) {
       final walletKeyId = await getWalletKeyId(vmId);
@@ -123,10 +131,7 @@ class DidWebManager extends DidManager {
     required PublicKey publicKey,
     required Set<VerificationRelationship> relationships,
   }) async {
-    final createdRelationships = <VerificationRelationship, String>{};
-    String? primaryVmId;
-
-    // If no relationships are specified, create one VM not attached to any purpose.
+    // ── Empty relationships: one unattached VM ──
     if (relationships.isEmpty) {
       final vmId = await buildVerificationMethodId(publicKey);
       await store.setMapping(vmId, walletKeyId);
@@ -136,8 +141,30 @@ class DidWebManager extends DidManager {
       );
     }
 
-    // Define a fixed order for processing relationships to ensure consistent
-    // DID document generation.
+    final createdRelationships = <VerificationRelationship, String>{};
+
+    // ── Determine whether we need a primary (non-keyAgreement) VM ──
+    // Skip it only when the SOLE relationship is keyAgreement on an ed25519 key
+    // (in that case only the derived X25519 VM is needed).
+    final needsPrimaryVm = !(relationships.length == 1 &&
+        relationships.first == VerificationRelationship.keyAgreement &&
+        publicKey.type == KeyType.ed25519);
+
+    // ── Build the PRIMARY VM id once — reused for all non-keyAgreement
+    //    relationships (and for keyAgreement when the key is not ed25519). ──
+    String? primaryVmId;
+    if (needsPrimaryVm) {
+      primaryVmId = await buildVerificationMethodId(publicKey);
+      await addVerificationMethodFromPublicKey(
+        publicKey,
+        verificationMethodId: primaryVmId,
+      );
+    }
+
+    // ── Build the DERIVED X25519 VM lazily — only for ed25519 + keyAgreement ──
+    String? derivedVmId;
+
+    // Fixed processing order for consistent DID document generation.
     const processingOrder = [
       VerificationRelationship.authentication,
       VerificationRelationship.keyAgreement,
@@ -146,52 +173,45 @@ class DidWebManager extends DidManager {
       VerificationRelationship.assertionMethod,
     ];
 
-    final orderedRelationships =
-        processingOrder.where((r) => relationships.contains(r));
-
-    for (final relationship in orderedRelationships) {
-      final String vmId;
-      // Special handling for keyAgreement with Ed25519 keys:
-      // derive X25519 key for key agreement
+    for (final relationship
+        in processingOrder.where((r) => relationships.contains(r))) {
       if (relationship == VerificationRelationship.keyAgreement &&
           publicKey.type == KeyType.ed25519) {
-        final x25519PublicKeyBytes =
-            ed25519PublicToX25519Public(publicKey.bytes);
-        final keyAgreementPublicKey =
-            PublicKey(publicKey.id, x25519PublicKeyBytes, KeyType.x25519);
-        vmId = await buildVerificationMethodId(keyAgreementPublicKey);
+        // Derive X25519 VM once (lazy).
+        if (derivedVmId == null) {
+          final x25519Bytes = ed25519PublicToX25519Public(publicKey.bytes);
+          final x25519Key =
+              PublicKey(publicKey.id, x25519Bytes, KeyType.x25519);
+          derivedVmId = await buildVerificationMethodId(x25519Key);
+          await addVerificationMethodFromPublicKey(
+            x25519Key,
+            verificationMethodId: derivedVmId,
+          );
+        }
+        await addKeyAgreement(derivedVmId);
+        createdRelationships[relationship] = derivedVmId;
       } else {
-        vmId = await buildVerificationMethodId(publicKey);
+        // All other relationships share the primary VM.
+        switch (relationship) {
+          case VerificationRelationship.authentication:
+            await addAuthentication(primaryVmId!);
+          case VerificationRelationship.assertionMethod:
+            await addAssertionMethod(primaryVmId!);
+          case VerificationRelationship.capabilityInvocation:
+            await addCapabilityInvocation(primaryVmId!);
+          case VerificationRelationship.capabilityDelegation:
+            await addCapabilityDelegation(primaryVmId!);
+          case VerificationRelationship.keyAgreement:
+            await addKeyAgreement(primaryVmId!);
+        }
+        createdRelationships[relationship] = primaryVmId;
       }
-
-      await addVerificationMethodFromPublicKey(
-        publicKey,
-        verificationMethodId: vmId,
-      );
-      primaryVmId ??= vmId;
-
-      switch (relationship) {
-        case VerificationRelationship.authentication:
-          await addAuthentication(vmId);
-          break;
-        case VerificationRelationship.assertionMethod:
-          await addAssertionMethod(vmId);
-          break;
-        case VerificationRelationship.capabilityInvocation:
-          await addCapabilityInvocation(vmId);
-          break;
-        case VerificationRelationship.capabilityDelegation:
-          await addCapabilityDelegation(vmId);
-          break;
-        case VerificationRelationship.keyAgreement:
-          await addKeyAgreement(vmId);
-          break;
-      }
-      createdRelationships[relationship] = vmId;
     }
 
+    assert(primaryVmId != null || derivedVmId != null);
+
     return AddVerificationMethodResult(
-      verificationMethodId: primaryVmId!,
+      verificationMethodId: primaryVmId ?? derivedVmId!,
       relationships: createdRelationships,
     );
   }

--- a/lib/src/did/did_peer.dart
+++ b/lib/src/did/did_peer.dart
@@ -235,7 +235,7 @@ DidDocument _resolveDidPeer2(String did) {
       case 'I':
       case 'D':
         keyIndex++;
-        final kid = '#key-$keyIndex';
+        final kid = '$did#key-$keyIndex';
         final verification = VerificationMethodMultibase(
           id: kid,
           controller: did,
@@ -466,12 +466,17 @@ class DidPeer {
       'https://w3id.org/security/multikey/v1'
     ];
 
+    // Expands a fragment-only ID (e.g. '#key-1') to fully-qualified form
+    // (e.g. 'did:peer:2...#key-1'). Already-absolute IDs are left unchanged.
+    String toFullId(String id) => id.startsWith('#') ? '$did$id' : id;
+    List<String> toFullIds(List<String>? ids) =>
+        ids?.map(toFullId).toList() ?? [];
+
     final vms = <EmbeddedVerificationMethod>[];
     for (var i = 0; i < verificationMethodIds.length; i++) {
-      final vmId = verificationMethodIds[i];
       final pubKey = publicKeys[i];
       vms.add(VerificationMethodMultibase(
-        id: vmId,
+        id: toFullId(verificationMethodIds[i]),
         controller: did,
         type: 'Multikey',
         publicKeyMultibase: toMultiBase(toMultikey(pubKey.bytes, pubKey.type)),
@@ -483,14 +488,15 @@ class DidPeer {
       id: did,
       verificationMethod: vms,
       authentication:
-          relationships[VerificationRelationship.authentication] ?? [],
-      keyAgreement: relationships[VerificationRelationship.keyAgreement] ?? [],
+          toFullIds(relationships[VerificationRelationship.authentication]),
+      keyAgreement:
+          toFullIds(relationships[VerificationRelationship.keyAgreement]),
       assertionMethod:
-          relationships[VerificationRelationship.assertionMethod] ?? [],
-      capabilityInvocation:
-          relationships[VerificationRelationship.capabilityInvocation] ?? [],
-      capabilityDelegation:
-          relationships[VerificationRelationship.capabilityDelegation] ?? [],
+          toFullIds(relationships[VerificationRelationship.assertionMethod]),
+      capabilityInvocation: toFullIds(
+          relationships[VerificationRelationship.capabilityInvocation]),
+      capabilityDelegation: toFullIds(
+          relationships[VerificationRelationship.capabilityDelegation]),
       service: serviceEndpoints,
     );
   }

--- a/test/did/did_manager/did_peer_manager_test.dart
+++ b/test/did/did_manager/did_peer_manager_test.dart
@@ -455,20 +455,17 @@ void main() {
         expect(document.authentication.length, 1);
       });
 
-      test('should create separate verification methods for each purpose',
+      test('should create ONE verification method shared across purposes',
           () async {
-        // Arrange
         final key = await wallet.generateKey(
             keyId: 'multi-purpose-key', keyType: KeyType.p256);
 
-        // Act
         final result =
             await manager.addVerificationMethod(key.id, relationships: {
           VerificationRelationship.authentication,
           VerificationRelationship.assertionMethod,
         });
 
-        // Assert
         final authVmId =
             result.relationships[VerificationRelationship.authentication];
         final assertVmId =
@@ -476,23 +473,27 @@ void main() {
 
         expect(authVmId, isNotNull);
         expect(assertVmId, isNotNull);
-        expect(authVmId, isNot(equals(assertVmId)),
-            reason: 'Each purpose should have a unique verification method ID');
+        // One-to-one: same VM for both purposes
+        expect(authVmId, equals(assertVmId),
+            reason: 'Both purposes should share one verification method ID');
 
         final storeAuth = await store.authentication;
         final storeAssert = await store.assertionMethod;
 
         expect(storeAuth, [authVmId]);
-        expect(storeAssert, [assertVmId]);
+        expect(storeAssert, [authVmId]); // same VM ID
 
         final allVmIds = await store.verificationMethodIds;
-        expect(allVmIds, hasLength(2));
-        expect(allVmIds, containsAll([authVmId, assertVmId]));
+        expect(allVmIds, hasLength(1)); // just 1 VM
+        expect(allVmIds, contains(authVmId));
 
         final doc = await manager.getDidDocument();
-        expect(doc.authentication.first.id, authVmId);
-        expect(doc.assertionMethod.first.id, assertVmId);
-        expect(doc.verificationMethod, hasLength(2));
+        // With 1 VM, did:peer:0 is generated — VM IDs are fully qualified.
+        expect(doc.verificationMethod, hasLength(1));
+        expect(doc.authentication, hasLength(1));
+        expect(doc.assertionMethod, hasLength(1));
+        // The important check: auth and assertion reference the SAME VM.
+        expect(doc.authentication.first.id, doc.assertionMethod.first.id);
       });
 
       test('should maintain verification method order across manager instances',
@@ -817,6 +818,63 @@ void main() {
         // Verify resolution and content
         final resolvedDoc = DidPeer.resolve(didDocument.id);
         expect(resolvedDoc.toJson(), didDocument.toJson());
+      });
+    });
+
+    // ================================================================
+    // One-to-one key → VM mapping tests
+    // ================================================================
+    group('One-to-one key to VM mapping', () {
+      test(
+          '1 p256 key with {auth, assertion, capInvoke} → 1 VM shared across all',
+          () async {
+        final key =
+            await wallet.generateKey(keyId: 'p256-3rel', keyType: KeyType.p256);
+        final result = await manager.addVerificationMethod(
+          key.id,
+          relationships: {
+            VerificationRelationship.authentication,
+            VerificationRelationship.assertionMethod,
+            VerificationRelationship.capabilityInvocation,
+          },
+        );
+
+        // All relationships map to the same VM
+        final vmId = result.verificationMethodId;
+        expect(result.relationships[VerificationRelationship.authentication],
+            vmId);
+        expect(result.relationships[VerificationRelationship.assertionMethod],
+            vmId);
+        expect(
+            result.relationships[VerificationRelationship.capabilityInvocation],
+            vmId);
+
+        final allVmIds = await store.verificationMethodIds;
+        expect(allVmIds, hasLength(1));
+      });
+
+      test(
+          'ed25519 key with {auth, keyAgreement} → 2 VMs: ed25519 + derived X25519',
+          () async {
+        final key = await wallet.generateKey(
+            keyId: 'ed-2rel', keyType: KeyType.ed25519);
+        final result = await manager.addVerificationMethod(
+          key.id,
+          relationships: {
+            VerificationRelationship.authentication,
+            VerificationRelationship.keyAgreement,
+          },
+        );
+
+        final authVmId =
+            result.relationships[VerificationRelationship.authentication]!;
+        final kaVmId =
+            result.relationships[VerificationRelationship.keyAgreement]!;
+        expect(authVmId, isNot(kaVmId)); // ed25519 vs X25519 = different VMs
+        expect(result.verificationMethodId, authVmId); // primary is ed25519
+
+        final allVmIds = await store.verificationMethodIds;
+        expect(allVmIds, hasLength(2));
       });
     });
   });

--- a/test/did/did_manager/did_peer_manager_test.dart
+++ b/test/did/did_manager/did_peer_manager_test.dart
@@ -128,14 +128,16 @@ void main() {
 
         // Verify verification methods
         expect(didDocument.verificationMethod, hasLength(2));
-        expect(didDocument.verificationMethod[0].id, '#key-1');
+        expect(didDocument.verificationMethod[0].id, '${didDocument.id}#key-1');
         expect(didDocument.verificationMethod[0].type, 'Multikey');
-        expect(didDocument.verificationMethod[1].id, '#key-2');
+        expect(didDocument.verificationMethod[1].id, '${didDocument.id}#key-2');
         expect(didDocument.verificationMethod[1].type, 'Multikey');
 
         // Verify verification relationships
-        expect(didDocument.authentication.map((e) => e.id), ['#key-1']);
-        expect(didDocument.keyAgreement.map((e) => e.id), ['#key-2']);
+        expect(didDocument.authentication.map((e) => e.id).toList(),
+            ['${didDocument.id}#key-1']);
+        expect(didDocument.keyAgreement.map((e) => e.id).toList(),
+            ['${didDocument.id}#key-2']);
 
         // Cross-check: get key agreement id from doc and retrieve keypair from manager
         final keyAgreementId = didDocument.keyAgreement.first.id;
@@ -205,8 +207,14 @@ void main() {
         expect(document.id, startsWith('did:peer:2'));
         expect(document.verificationMethod.length, 3);
         expect(document.authentication.length, 3);
-        expect(document.authentication.map((ref) => ref.id).toList(),
-            containsAll([vmId1, vmId2, vmId3]));
+        expect(
+          document.authentication.map((ref) => ref.id).toList(),
+          containsAll([
+            '${document.id}$vmId1',
+            '${document.id}$vmId2',
+            '${document.id}$vmId3',
+          ]),
+        );
       });
     });
 
@@ -405,14 +413,25 @@ void main() {
         // Assert
         expect(document.id, startsWith('did:peer:2'));
         expect(
-            document.authentication.any((ref) => ref.id == vmIds[0]), isTrue);
-        expect(document.keyAgreement.any((ref) => ref.id == vmIds[1]), isTrue);
-        expect(document.capabilityInvocation.any((ref) => ref.id == vmIds[2]),
-            isTrue);
-        expect(document.capabilityDelegation.any((ref) => ref.id == vmIds[3]),
+            document.authentication
+                .any((ref) => ref.id == '${document.id}${vmIds[0]}'),
             isTrue);
         expect(
-            document.assertionMethod.any((ref) => ref.id == vmIds[4]), isTrue);
+            document.keyAgreement
+                .any((ref) => ref.id == '${document.id}${vmIds[1]}'),
+            isTrue);
+        expect(
+            document.capabilityInvocation
+                .any((ref) => ref.id == '${document.id}${vmIds[2]}'),
+            isTrue);
+        expect(
+            document.capabilityDelegation
+                .any((ref) => ref.id == '${document.id}${vmIds[3]}'),
+            isTrue);
+        expect(
+            document.assertionMethod
+                .any((ref) => ref.id == '${document.id}${vmIds[4]}'),
+            isTrue);
       });
 
       test('should remove verification method purposes', () async {
@@ -490,8 +509,8 @@ void main() {
         expect(allVmIds, containsAll([authVmId, assertVmId]));
 
         final doc = await manager.getDidDocument();
-        expect(doc.authentication.first.id, authVmId);
-        expect(doc.assertionMethod.first.id, assertVmId);
+        expect(doc.authentication.first.id, '${doc.id}$authVmId');
+        expect(doc.assertionMethod.first.id, '${doc.id}$assertVmId');
         expect(doc.verificationMethod, hasLength(2));
       });
 
@@ -523,11 +542,15 @@ void main() {
         final doc1 = await manager.getDidDocument();
         expect(doc1.id, startsWith('did:peer:2'));
         expect(doc1.verificationMethod, hasLength(3));
-        expect(doc1.verificationMethod.map((vm) => vm.id).toList(),
-            [authVmId1, kaVmId1, authVmId2]);
+        expect(doc1.verificationMethod.map((vm) => vm.id).toList(), [
+          '${doc1.id}$authVmId1',
+          '${doc1.id}$kaVmId1',
+          '${doc1.id}$authVmId2'
+        ]);
         expect(doc1.authentication.map((ref) => ref.id).toList(),
-            [authVmId1, authVmId2]);
-        expect(doc1.keyAgreement.map((ref) => ref.id).toList(), [kaVmId1]);
+            ['${doc1.id}$authVmId1', '${doc1.id}$authVmId2']);
+        expect(doc1.keyAgreement.map((ref) => ref.id).toList(),
+            ['${doc1.id}$kaVmId1']);
 
         // Compare resolved doc with originally created doc
         final resolvedDoc1 = DidPeer.resolve(doc1.id);

--- a/test/did/did_manager/did_web_manager_test.dart
+++ b/test/did/did_manager/did_web_manager_test.dart
@@ -601,17 +601,12 @@ void main() {
         final doc = await manager.getDidDocument();
         final json = doc.toJson();
 
-        // --- DID ---
         expect(doc.id, 'did:web:example.com');
 
-        // --- verificationMethod ---
-        // Each key with {authentication, assertionMethod} creates 2 VMs
-        // (one per relationship), so 2 keys × 2 relationships = 4 VMs.
-        // key1 → #key-1 (authentication), #key-2 (assertionMethod)
-        // key2 → #key-3 (authentication), #key-4 (assertionMethod)
-        expect(doc.verificationMethod.length, 4);
+        // 2 VMs — one per key (not 4)
+        expect(doc.verificationMethod.length, 2);
 
-        for (var i = 0; i < 4; i++) {
+        for (var i = 0; i < 2; i++) {
           final vm = doc.verificationMethod[i] as VerificationMethodMultibase;
           expect(vm.id, 'did:web:example.com#key-${i + 1}');
           expect(vm.controller, 'did:web:example.com');
@@ -619,38 +614,27 @@ void main() {
           expect(vm.publicKeyMultibase, startsWith('z6Mk')); // ed25519
         }
 
-        // key1 VMs (#key-1 and #key-2) share the same public key material
+        // key1 and key2 are different keys
         final vm1mb = (doc.verificationMethod[0] as VerificationMethodMultibase)
             .publicKeyMultibase;
         final vm2mb = (doc.verificationMethod[1] as VerificationMethodMultibase)
             .publicKeyMultibase;
-        expect(vm1mb, vm2mb);
+        expect(vm1mb, isNot(vm2mb));
 
-        // key2 VMs (#key-3 and #key-4) share the same public key material
-        final vm3mb = (doc.verificationMethod[2] as VerificationMethodMultibase)
-            .publicKeyMultibase;
-        final vm4mb = (doc.verificationMethod[3] as VerificationMethodMultibase)
-            .publicKeyMultibase;
-        expect(vm3mb, vm4mb);
-
-        // key1 and key2 are different keys
-        expect(vm1mb, isNot(vm3mb));
-
-        // --- authentication: #key-1 (key1) + #key-3 (key2) ---
+        // authentication: both keys
         expect(doc.authentication.length, 2);
         expect(json['authentication'], [
           'did:web:example.com#key-1',
-          'did:web:example.com#key-3',
+          'did:web:example.com#key-2',
         ]);
 
-        // --- assertionMethod: #key-2 (key1) + #key-4 (key2) ---
+        // assertionMethod: same VMs (one-to-one reuse)
         expect(doc.assertionMethod.length, 2);
         expect(json['assertionMethod'], [
+          'did:web:example.com#key-1',
           'did:web:example.com#key-2',
-          'did:web:example.com#key-4',
         ]);
 
-        // --- unused relationships are empty ---
         expect(doc.keyAgreement, isEmpty);
         expect(doc.capabilityInvocation, isEmpty);
         expect(doc.capabilityDelegation, isEmpty);
@@ -677,18 +661,12 @@ void main() {
         final doc = await manager.getDidDocument();
         final json = doc.toJson();
 
-        // --- DID ---
         expect(doc.id, 'did:web:example.com');
 
-        // --- verificationMethod ---
-        // Each p256 key with {authentication, keyAgreement} creates 2 VMs
-        // (one per relationship), so 3 keys × 2 relationships = 6 VMs.
-        // key1 → #key-1 (authentication), #key-2 (keyAgreement)
-        // key2 → #key-3 (authentication), #key-4 (keyAgreement)
-        // key3 → #key-5 (authentication), #key-6 (keyAgreement)
-        expect(doc.verificationMethod.length, 6);
+        // 3 VMs — one per key (not 6)
+        expect(doc.verificationMethod.length, 3);
 
-        for (var i = 0; i < 6; i++) {
+        for (var i = 0; i < 3; i++) {
           final vm = doc.verificationMethod[i] as VerificationMethodMultibase;
           expect(vm.id, 'did:web:example.com#key-${i + 1}');
           expect(vm.controller, 'did:web:example.com');
@@ -696,43 +674,29 @@ void main() {
           expect(vm.publicKeyMultibase, startsWith('zDn')); // p256
         }
 
-        // Pairs share the same public key material (same wallet key)
-        for (var pairStart in [0, 2, 4]) {
-          final mbA =
-              (doc.verificationMethod[pairStart] as VerificationMethodMultibase)
-                  .publicKeyMultibase;
-          final mbB = (doc.verificationMethod[pairStart + 1]
-                  as VerificationMethodMultibase)
-              .publicKeyMultibase;
-          expect(mbA, mbB);
-        }
-
         // Different wallet keys have different public material
         final mb1 = (doc.verificationMethod[0] as VerificationMethodMultibase)
             .publicKeyMultibase;
+        final mb2 = (doc.verificationMethod[1] as VerificationMethodMultibase)
+            .publicKeyMultibase;
         final mb3 = (doc.verificationMethod[2] as VerificationMethodMultibase)
             .publicKeyMultibase;
-        final mb5 = (doc.verificationMethod[4] as VerificationMethodMultibase)
-            .publicKeyMultibase;
-        expect({mb1, mb3, mb5}.length, 3); // all distinct
+        expect({mb1, mb2, mb3}.length, 3); // all distinct
 
-        // --- authentication: #key-1, #key-3, #key-5 ---
-        expect(doc.authentication.length, 3);
+        // authentication: all 3 keys
         expect(json['authentication'], [
           'did:web:example.com#key-1',
-          'did:web:example.com#key-3',
-          'did:web:example.com#key-5',
-        ]);
-
-        // --- keyAgreement: #key-2, #key-4, #key-6 ---
-        expect(doc.keyAgreement.length, 3);
-        expect(json['keyAgreement'], [
           'did:web:example.com#key-2',
-          'did:web:example.com#key-4',
-          'did:web:example.com#key-6',
+          'did:web:example.com#key-3',
         ]);
 
-        // --- unused relationships ---
+        // keyAgreement: same 3 VMs (p256 does not require X25519 derivation)
+        expect(json['keyAgreement'], [
+          'did:web:example.com#key-1',
+          'did:web:example.com#key-2',
+          'did:web:example.com#key-3',
+        ]);
+
         expect(doc.assertionMethod, isEmpty);
         expect(doc.capabilityInvocation, isEmpty);
         expect(doc.capabilityDelegation, isEmpty);
@@ -763,49 +727,36 @@ void main() {
         final doc = await manager.getDidDocument();
         final json = doc.toJson();
 
-        // --- verificationMethod ---
-        // 2 keys × 2 relationships = 4 VMs
-        // key1 → #key-1 (capabilityInvocation), #key-2 (assertionMethod)
-        // key2 → #key-3 (capabilityInvocation), #key-4 (assertionMethod)
-        // Note: processingOrder is auth, keyAgreement, capInvoke, capDelegate, assertion
-        expect(doc.verificationMethod.length, 4);
+        // 2 VMs — one per key (not 4)
+        expect(doc.verificationMethod.length, 2);
 
-        for (var i = 0; i < 4; i++) {
+        for (var i = 0; i < 2; i++) {
           final vm = doc.verificationMethod[i] as VerificationMethodMultibase;
           expect(vm.id, 'did:web:example.com#key-${i + 1}');
           expect(vm.type, 'Multikey');
           expect(vm.publicKeyMultibase, startsWith('zQ3s')); // secp256k1
         }
 
-        // key1 pair shares same material, key2 pair shares same material
         final vm1mb = (doc.verificationMethod[0] as VerificationMethodMultibase)
             .publicKeyMultibase;
         final vm2mb = (doc.verificationMethod[1] as VerificationMethodMultibase)
             .publicKeyMultibase;
-        expect(vm1mb, vm2mb);
+        expect(vm1mb, isNot(vm2mb));
 
-        final vm3mb = (doc.verificationMethod[2] as VerificationMethodMultibase)
-            .publicKeyMultibase;
-        final vm4mb = (doc.verificationMethod[3] as VerificationMethodMultibase)
-            .publicKeyMultibase;
-        expect(vm3mb, vm4mb);
-        expect(vm1mb, isNot(vm3mb));
-
-        // --- capabilityInvocation: #key-1, #key-3 ---
+        // capabilityInvocation: #key-1, #key-2
         expect(doc.capabilityInvocation.length, 2);
         expect(json['capabilityInvocation'], [
           'did:web:example.com#key-1',
-          'did:web:example.com#key-3',
+          'did:web:example.com#key-2',
         ]);
 
-        // --- assertionMethod: #key-2, #key-4 ---
+        // assertionMethod: same VMs #key-1, #key-2
         expect(doc.assertionMethod.length, 2);
         expect(json['assertionMethod'], [
+          'did:web:example.com#key-1',
           'did:web:example.com#key-2',
-          'did:web:example.com#key-4',
         ]);
 
-        // --- unused ---
         expect(doc.authentication, isEmpty);
         expect(doc.keyAgreement, isEmpty);
         expect(doc.capabilityDelegation, isEmpty);
@@ -837,45 +788,32 @@ void main() {
         final doc = await manager.getDidDocument();
         final json = doc.toJson();
 
-        // --- verificationMethod ---
-        // 3 keys × 3 relationships = 9 VMs
-        // processingOrder: authentication, keyAgreement, ..., assertionMethod
-        // key1 → #key-1 (auth), #key-2 (keyAgreement), #key-3 (assertion)
-        // key2 → #key-4 (auth), #key-5 (keyAgreement), #key-6 (assertion)
-        // key3 → #key-7 (auth), #key-8 (keyAgreement), #key-9 (assertion)
-        expect(doc.verificationMethod.length, 9);
-        for (var i = 0; i < 9; i++) {
+        // 3 VMs — one per key (not 9)
+        expect(doc.verificationMethod.length, 3);
+
+        for (var i = 0; i < 3; i++) {
           final vm = doc.verificationMethod[i] as VerificationMethodMultibase;
           expect(vm.id, 'did:web:example.com#key-${i + 1}');
           expect(vm.type, 'Multikey');
           expect(vm.publicKeyMultibase, startsWith('zQ3s'));
         }
 
-        // --- authentication: #key-1, #key-4, #key-7 ---
-        expect(doc.authentication.length, 3);
         expect(json['authentication'], [
           'did:web:example.com#key-1',
-          'did:web:example.com#key-4',
-          'did:web:example.com#key-7',
-        ]);
-
-        // --- keyAgreement: #key-2, #key-5, #key-8 ---
-        expect(doc.keyAgreement.length, 3);
-        expect(json['keyAgreement'], [
           'did:web:example.com#key-2',
-          'did:web:example.com#key-5',
-          'did:web:example.com#key-8',
-        ]);
-
-        // --- assertionMethod: #key-3, #key-6, #key-9 ---
-        expect(doc.assertionMethod.length, 3);
-        expect(json['assertionMethod'], [
           'did:web:example.com#key-3',
-          'did:web:example.com#key-6',
-          'did:web:example.com#key-9',
+        ]);
+        expect(json['keyAgreement'], [
+          'did:web:example.com#key-1',
+          'did:web:example.com#key-2',
+          'did:web:example.com#key-3',
+        ]);
+        expect(json['assertionMethod'], [
+          'did:web:example.com#key-1',
+          'did:web:example.com#key-2',
+          'did:web:example.com#key-3',
         ]);
 
-        // --- unused ---
         expect(doc.capabilityInvocation, isEmpty);
         expect(doc.capabilityDelegation, isEmpty);
       });
@@ -911,58 +849,30 @@ void main() {
         final doc = await manager.getDidDocument();
         final json = doc.toJson();
 
-        // --- DID ---
         expect(doc.id, 'did:web:example.com');
 
-        // --- verificationMethod ---
-        // 2 keys × 2 relationships = 4 VMs
-        // ed25519 → #key-1 (auth), #key-2 (assertion)
-        // p256    → #key-3 (auth), #key-4 (assertion)
-        expect(doc.verificationMethod.length, 4);
+        // 2 VMs — one per key (not 4)
+        expect(doc.verificationMethod.length, 2);
 
-        // VM 1: ed25519 (authentication)
         final vm1 = doc.verificationMethod[0] as VerificationMethodMultibase;
         expect(vm1.id, 'did:web:example.com#key-1');
-        expect(vm1.controller, 'did:web:example.com');
-        expect(vm1.type, 'Multikey');
         expect(vm1.publicKeyMultibase, startsWith('z6Mk')); // ed25519
 
-        // VM 2: ed25519 (assertionMethod) — same key material as VM 1
         final vm2 = doc.verificationMethod[1] as VerificationMethodMultibase;
         expect(vm2.id, 'did:web:example.com#key-2');
-        expect(vm2.type, 'Multikey');
-        expect(vm2.publicKeyMultibase, startsWith('z6Mk')); // ed25519
-        expect(vm2.publicKeyMultibase, vm1.publicKeyMultibase);
+        expect(vm2.publicKeyMultibase, startsWith('zDn')); // p256
 
-        // VM 3: p256 (authentication)
-        final vm3 = doc.verificationMethod[2] as VerificationMethodMultibase;
-        expect(vm3.id, 'did:web:example.com#key-3');
-        expect(vm3.controller, 'did:web:example.com');
-        expect(vm3.type, 'Multikey');
-        expect(vm3.publicKeyMultibase, startsWith('zDn')); // p256
-
-        // VM 4: p256 (assertionMethod) — same key material as VM 3
-        final vm4 = doc.verificationMethod[3] as VerificationMethodMultibase;
-        expect(vm4.id, 'did:web:example.com#key-4');
-        expect(vm4.type, 'Multikey');
-        expect(vm4.publicKeyMultibase, startsWith('zDn')); // p256
-        expect(vm4.publicKeyMultibase, vm3.publicKeyMultibase);
-
-        // --- authentication: #key-1 (ed25519) + #key-3 (p256) ---
-        expect(doc.authentication.length, 2);
+        // authentication: #key-1 (ed25519) + #key-2 (p256)
         expect(json['authentication'], [
           'did:web:example.com#key-1',
-          'did:web:example.com#key-3',
-        ]);
-
-        // --- assertionMethod: #key-2 (ed25519) + #key-4 (p256) ---
-        expect(doc.assertionMethod.length, 2);
-        expect(json['assertionMethod'], [
           'did:web:example.com#key-2',
-          'did:web:example.com#key-4',
+        ]);
+        // assertionMethod: same VMs
+        expect(json['assertionMethod'], [
+          'did:web:example.com#key-1',
+          'did:web:example.com#key-2',
         ]);
 
-        // --- unused ---
         expect(doc.keyAgreement, isEmpty);
         expect(doc.capabilityInvocation, isEmpty);
         expect(doc.capabilityDelegation, isEmpty);
@@ -1043,110 +953,50 @@ void main() {
         final doc = await manager.getDidDocument();
         final json = doc.toJson();
 
-        // --- DID ---
         expect(doc.id, 'did:web:example.com');
 
-        // --- verificationMethod ---
-        // processingOrder: authentication, keyAgreement, ..., assertionMethod
-        //
-        // ed25519 key:
-        //   #key-1 (auth, ed25519)
-        //   #key-2 (keyAgreement, x25519 — derived from ed25519)
-        //   #key-3 (assertion, ed25519)
-        // p256 key:
-        //   #key-4 (auth, p256)
-        //   #key-5 (keyAgreement, p256)
-        //   #key-6 (assertion, p256)
-        // secp256k1 key:
-        //   #key-7 (auth, secp256k1)
-        //   #key-8 (keyAgreement, secp256k1)
-        //   #key-9 (assertion, secp256k1)
-        expect(doc.verificationMethod.length, 9);
+        // 4 VMs (not 9):
+        // #key-1  ed25519   (auth + assertion for ed25519 key)
+        // #key-2  x25519    (keyAgreement derived from ed25519 key)
+        // #key-3  p256      (auth + keyAgreement + assertion for p256 key)
+        // #key-4  secp256k1 (auth + keyAgreement + assertion for secp256k1 key)
+        expect(doc.verificationMethod.length, 4);
 
-        // VM 1: ed25519 (authentication)
         final vm1 = doc.verificationMethod[0] as VerificationMethodMultibase;
         expect(vm1.id, 'did:web:example.com#key-1');
-        expect(vm1.type, 'Multikey');
         expect(vm1.publicKeyMultibase, startsWith('z6Mk')); // ed25519
 
-        // VM 2: x25519 (keyAgreement — derived from ed25519)
         final vm2 = doc.verificationMethod[1] as VerificationMethodMultibase;
         expect(vm2.id, 'did:web:example.com#key-2');
-        expect(vm2.type, 'Multikey');
-        expect(vm2.publicKeyMultibase, startsWith('z6LS')); // x25519
+        expect(vm2.publicKeyMultibase, startsWith('z6LS')); // x25519 derived
 
-        // VM 3: ed25519 (assertionMethod)
         final vm3 = doc.verificationMethod[2] as VerificationMethodMultibase;
         expect(vm3.id, 'did:web:example.com#key-3');
-        expect(vm3.type, 'Multikey');
-        expect(vm3.publicKeyMultibase, startsWith('z6Mk')); // ed25519
-        expect(vm3.publicKeyMultibase, vm1.publicKeyMultibase); // same key
+        expect(vm3.publicKeyMultibase, startsWith('zDn')); // p256
 
-        // VM 4: p256 (authentication)
         final vm4 = doc.verificationMethod[3] as VerificationMethodMultibase;
         expect(vm4.id, 'did:web:example.com#key-4');
-        expect(vm4.type, 'Multikey');
-        expect(vm4.publicKeyMultibase, startsWith('zDn')); // p256
+        expect(vm4.publicKeyMultibase, startsWith('zQ3s')); // secp256k1
 
-        // VM 5: p256 (keyAgreement)
-        final vm5 = doc.verificationMethod[4] as VerificationMethodMultibase;
-        expect(vm5.id, 'did:web:example.com#key-5');
-        expect(vm5.type, 'Multikey');
-        expect(vm5.publicKeyMultibase, startsWith('zDn')); // p256
-        expect(vm5.publicKeyMultibase, vm4.publicKeyMultibase); // same key
-
-        // VM 6: p256 (assertionMethod)
-        final vm6 = doc.verificationMethod[5] as VerificationMethodMultibase;
-        expect(vm6.id, 'did:web:example.com#key-6');
-        expect(vm6.type, 'Multikey');
-        expect(vm6.publicKeyMultibase, startsWith('zDn')); // p256
-        expect(vm6.publicKeyMultibase, vm4.publicKeyMultibase); // same key
-
-        // VM 7: secp256k1 (authentication)
-        final vm7 = doc.verificationMethod[6] as VerificationMethodMultibase;
-        expect(vm7.id, 'did:web:example.com#key-7');
-        expect(vm7.type, 'Multikey');
-        expect(vm7.publicKeyMultibase, startsWith('zQ3s')); // secp256k1
-
-        // VM 8: secp256k1 (keyAgreement)
-        final vm8 = doc.verificationMethod[7] as VerificationMethodMultibase;
-        expect(vm8.id, 'did:web:example.com#key-8');
-        expect(vm8.type, 'Multikey');
-        expect(vm8.publicKeyMultibase, startsWith('zQ3s')); // secp256k1
-        expect(vm8.publicKeyMultibase, vm7.publicKeyMultibase); // same key
-
-        // VM 9: secp256k1 (assertionMethod)
-        final vm9 = doc.verificationMethod[8] as VerificationMethodMultibase;
-        expect(vm9.id, 'did:web:example.com#key-9');
-        expect(vm9.type, 'Multikey');
-        expect(vm9.publicKeyMultibase, startsWith('zQ3s')); // secp256k1
-        expect(vm9.publicKeyMultibase, vm7.publicKeyMultibase); // same key
-
-        // --- authentication: #key-1 (ed25519), #key-4 (p256), #key-7 (secp256k1) ---
-        expect(doc.authentication.length, 3);
+        // authentication: ed25519(#key-1), p256(#key-3), secp256k1(#key-4)
         expect(json['authentication'], [
           'did:web:example.com#key-1',
+          'did:web:example.com#key-3',
           'did:web:example.com#key-4',
-          'did:web:example.com#key-7',
         ]);
-
-        // --- keyAgreement: #key-2 (x25519), #key-5 (p256), #key-8 (secp256k1) ---
-        expect(doc.keyAgreement.length, 3);
+        // keyAgreement: x25519(#key-2), p256(#key-3), secp256k1(#key-4)
         expect(json['keyAgreement'], [
           'did:web:example.com#key-2',
-          'did:web:example.com#key-5',
-          'did:web:example.com#key-8',
-        ]);
-
-        // --- assertionMethod: #key-3 (ed25519), #key-6 (p256), #key-9 (secp256k1) ---
-        expect(doc.assertionMethod.length, 3);
-        expect(json['assertionMethod'], [
           'did:web:example.com#key-3',
-          'did:web:example.com#key-6',
-          'did:web:example.com#key-9',
+          'did:web:example.com#key-4',
+        ]);
+        // assertionMethod: ed25519(#key-1), p256(#key-3), secp256k1(#key-4)
+        expect(json['assertionMethod'], [
+          'did:web:example.com#key-1',
+          'did:web:example.com#key-3',
+          'did:web:example.com#key-4',
         ]);
 
-        // --- unused ---
         expect(doc.capabilityInvocation, isEmpty);
         expect(doc.capabilityDelegation, isEmpty);
       });
@@ -1205,6 +1055,188 @@ void main() {
         expect(doc.capabilityInvocation, isEmpty);
         expect(doc.capabilityDelegation, isEmpty);
       });
+    });
+
+    // ================================================================
+    // One-to-one key → VM mapping tests
+    // ================================================================
+    group('One-to-one key to VM mapping', () {
+      test(
+        '1 ed25519 key with {auth, assertion, capInvoke, capDelegate} → 1 VM, all 4 arrays reference it',
+        () async {
+          final key = await wallet.generateKey(
+              keyId: 'ed-4rel', keyType: KeyType.ed25519);
+          await manager.addVerificationMethod(
+            key.id,
+            relationships: {
+              VerificationRelationship.authentication,
+              VerificationRelationship.assertionMethod,
+              VerificationRelationship.capabilityInvocation,
+              VerificationRelationship.capabilityDelegation,
+            },
+          );
+          final doc = await manager.getDidDocument();
+          expect(doc.verificationMethod.length, 1);
+          expect(doc.verificationMethod.first.id, 'did:web:example.com#key-1');
+          expect(doc.authentication.first.id, 'did:web:example.com#key-1');
+          expect(doc.assertionMethod.first.id, 'did:web:example.com#key-1');
+          expect(
+              doc.capabilityInvocation.first.id, 'did:web:example.com#key-1');
+          expect(
+              doc.capabilityDelegation.first.id, 'did:web:example.com#key-1');
+          expect(doc.keyAgreement, isEmpty);
+        },
+      );
+
+      test(
+        '1 p256 key with {auth, keyAgreement} → 1 VM, both arrays reference same VM',
+        () async {
+          final key = await wallet.generateKey(
+              keyId: 'p256-2rel', keyType: KeyType.p256);
+          await manager.addVerificationMethod(
+            key.id,
+            relationships: {
+              VerificationRelationship.authentication,
+              VerificationRelationship.keyAgreement,
+            },
+          );
+          final doc = await manager.getDidDocument();
+          expect(doc.verificationMethod.length, 1);
+          expect(doc.verificationMethod.first.id, 'did:web:example.com#key-1');
+          expect(doc.authentication.first.id, 'did:web:example.com#key-1');
+          expect(doc.keyAgreement.first.id, 'did:web:example.com#key-1');
+        },
+      );
+
+      test(
+        'ed25519 key with all 5 relationships → exactly 2 VMs: #key-1 (ed25519) + #key-2 (X25519)',
+        () async {
+          final key = await wallet.generateKey(
+              keyId: 'ed-all5', keyType: KeyType.ed25519);
+          final result = await manager.addVerificationMethod(
+            key.id,
+            relationships: {
+              VerificationRelationship.authentication,
+              VerificationRelationship.assertionMethod,
+              VerificationRelationship.keyAgreement,
+              VerificationRelationship.capabilityInvocation,
+              VerificationRelationship.capabilityDelegation,
+            },
+          );
+
+          // Primary VM is the ed25519 one
+          expect(result.verificationMethodId, 'did:web:example.com#key-1');
+          // keyAgreement maps to the derived X25519 VM
+          expect(result.relationships[VerificationRelationship.keyAgreement],
+              'did:web:example.com#key-2');
+          // All other relationships map to the primary VM
+          expect(result.relationships[VerificationRelationship.authentication],
+              'did:web:example.com#key-1');
+          expect(result.relationships[VerificationRelationship.assertionMethod],
+              'did:web:example.com#key-1');
+          expect(
+              result
+                  .relationships[VerificationRelationship.capabilityInvocation],
+              'did:web:example.com#key-1');
+          expect(
+              result
+                  .relationships[VerificationRelationship.capabilityDelegation],
+              'did:web:example.com#key-1');
+
+          final doc = await manager.getDidDocument();
+          expect(doc.verificationMethod.length, 2);
+
+          final vm1 = doc.verificationMethod[0] as VerificationMethodMultibase;
+          expect(vm1.id, 'did:web:example.com#key-1');
+          expect(vm1.publicKeyMultibase, startsWith('z6Mk')); // ed25519
+
+          final vm2 = doc.verificationMethod[1] as VerificationMethodMultibase;
+          expect(vm2.id, 'did:web:example.com#key-2');
+          expect(vm2.publicKeyMultibase, startsWith('z6LS')); // x25519
+
+          // non-keyAgreement arrays all reference #key-1
+          expect(doc.authentication.first.id, 'did:web:example.com#key-1');
+          expect(doc.assertionMethod.first.id, 'did:web:example.com#key-1');
+          expect(
+              doc.capabilityInvocation.first.id, 'did:web:example.com#key-1');
+          expect(
+              doc.capabilityDelegation.first.id, 'did:web:example.com#key-1');
+          // keyAgreement references the derived X25519
+          expect(doc.keyAgreement.first.id, 'did:web:example.com#key-2');
+        },
+      );
+
+      test(
+        'sign+verify still works after one-to-one fix: ed25519 key with auth+keyAgreement',
+        () async {
+          final key = await wallet.generateKey(
+              keyId: 'ed-sign', keyType: KeyType.ed25519);
+          final result = await manager.addVerificationMethod(
+            key.id,
+            relationships: {
+              VerificationRelationship.authentication,
+              VerificationRelationship.keyAgreement,
+            },
+          );
+
+          final authVmId =
+              result.relationships[VerificationRelationship.authentication]!;
+          final data = Uint8List.fromList([1, 2, 3, 4, 5]);
+          final sig = await manager.sign(data, authVmId);
+          expect(await manager.verify(data, sig, authVmId), isTrue);
+        },
+      );
+
+      test(
+        'ed25519 default relationships (all 5) produce exactly 2 VMs: ed25519 + derived X25519',
+        () async {
+          final key = await wallet.generateKey(
+              keyId: 'ed-default', keyType: KeyType.ed25519);
+
+          // No explicit relationships — defaults applied by base class:
+          // {auth, assertion, keyAgreement, capInvoke, capDelegate}
+          final result = await manager.addVerificationMethod(key.id);
+
+          // Primary VM is the ed25519 one
+          expect(result.verificationMethodId, 'did:web:example.com#key-1');
+
+          // keyAgreement maps to the derived X25519 VM
+          expect(result.relationships[VerificationRelationship.keyAgreement],
+              'did:web:example.com#key-2');
+
+          // All other relationships map to the primary VM
+          for (final rel in [
+            VerificationRelationship.authentication,
+            VerificationRelationship.assertionMethod,
+            VerificationRelationship.capabilityInvocation,
+            VerificationRelationship.capabilityDelegation,
+          ]) {
+            expect(result.relationships[rel], 'did:web:example.com#key-1');
+          }
+
+          final doc = await manager.getDidDocument();
+
+          // Exactly 2 VMs: #key-1 (ed25519) + #key-2 (x25519)
+          expect(doc.verificationMethod.length, 2);
+
+          final vm1 = doc.verificationMethod[0] as VerificationMethodMultibase;
+          expect(vm1.id, 'did:web:example.com#key-1');
+          expect(vm1.publicKeyMultibase, startsWith('z6Mk')); // ed25519
+
+          final vm2 = doc.verificationMethod[1] as VerificationMethodMultibase;
+          expect(vm2.id, 'did:web:example.com#key-2');
+          expect(vm2.publicKeyMultibase, startsWith('z6LS')); // x25519
+
+          // All non-keyAgreement arrays reference #key-1
+          final json = doc.toJson();
+          expect(json['authentication'], ['did:web:example.com#key-1']);
+          expect(json['assertionMethod'], ['did:web:example.com#key-1']);
+          expect(json['capabilityInvocation'], ['did:web:example.com#key-1']);
+          expect(json['capabilityDelegation'], ['did:web:example.com#key-1']);
+          // keyAgreement references the derived X25519
+          expect(json['keyAgreement'], ['did:web:example.com#key-2']);
+        },
+      );
     });
   });
 }

--- a/test/did/did_peer_test.dart
+++ b/test/did/did_peer_test.dart
@@ -181,8 +181,8 @@ void main() {
 
       // Verify verification methods are created correctly
       expect(doc.verificationMethod.length, 2);
-      expect(doc.verificationMethod[0].id, '#key-1');
-      expect(doc.verificationMethod[1].id, '#key-2');
+      expect(doc.verificationMethod[0].id, '${doc.id}#key-1');
+      expect(doc.verificationMethod[1].id, '${doc.id}#key-2');
     });
 
     test(
@@ -319,7 +319,7 @@ void main() {
       for (final vm in verificationMethods) {
         expect(vm.type, 'Multikey');
         expect(vm.controller, actualDid);
-        expect(vm.id, startsWith('#key-'));
+        expect(vm.id, startsWith('$actualDid#key-'));
       }
 
       // Assert authentication, assertionMethod, keyAgreement
@@ -328,8 +328,8 @@ void main() {
       final keyAgreementIds =
           resolvedDidDocument.keyAgreement.map((vm) => vm.id).toList();
       // By construction, last two keys are authentication/assertion, first two are keyAgreement
-      expect(authenticationIds, ['#key-1']);
-      expect(keyAgreementIds, ['#key-2']);
+      expect(authenticationIds, ['$actualDid#key-1']);
+      expect(keyAgreementIds, ['$actualDid#key-2']);
 
       // Assert capabilityDelegation and capabilityInvocation are empty
       expect(resolvedDidDocument.assertionMethod, isEmpty);

--- a/test/did/did_peer_vc_vp_issuance_test.dart
+++ b/test/did/did_peer_vc_vp_issuance_test.dart
@@ -38,14 +38,15 @@ void main() {
       expect(didDocument.id, startsWith('did:peer:2'));
 
       // Use first authentication key as signer
-      final authVmId = didDocument.authentication.first.id; // e.g. '#key-1'
+      final authVmId =
+          didDocument.authentication.first.id; // e.g. 'did:peer:2...#key-1'
       final walletKeyId = await manager.getWalletKeyId(authVmId);
       expect(walletKeyId, isNotNull);
       final keyPair = await wallet.getKeyPair(walletKeyId!);
 
       final signer = DidSigner(
         did: didDocument.id,
-        didKeyId: '${didDocument.id}$authVmId',
+        didKeyId: authVmId,
         keyPair: keyPair,
         signatureScheme: SignatureScheme.ecdsa_secp256k1_sha256,
       );
@@ -88,7 +89,7 @@ void main() {
 
       final signer = DidSigner(
         did: didDocument.id,
-        didKeyId: '${didDocument.id}$authVmId',
+        didKeyId: authVmId,
         keyPair: keyPair,
         signatureScheme: SignatureScheme.ecdsa_secp256k1_sha256,
       );


### PR DESCRIPTION
This pull request refactors the logic for mapping keys to verification methods (VMs) in both the `DidPeerManager` and `DidWebManager` classes, ensuring a one-to-one mapping between a key and its verification method across multiple purposes. It also clarifies and documents the handling of derived keys for key agreement, and updates the related tests to reflect these changes.

Key changes include:

### Core logic changes (DidPeerManager & DidWebManager)

* Refactored the process of adding verification methods so that a single key now produces only one VM shared across all specified relationships (purposes), except for the special case where an Ed25519 key is used for key agreement, which correctly derives and uses an X25519 VM. This ensures consistent and minimal DID document generation. [[1]](diffhunk://#diff-ff2fd81737377d8f0859516803dd6cb0a70c479e31d297814587ed7cc8a1787bL36-R36) [[2]](diffhunk://#diff-ff2fd81737377d8f0859516803dd6cb0a70c479e31d297814587ed7cc8a1787bL49-R66) [[3]](diffhunk://#diff-ff2fd81737377d8f0859516803dd6cb0a70c479e31d297814587ed7cc8a1787bL59-R112) [[4]](diffhunk://#diff-499f62cb5a2d3817bed7eac3c8269667bfc8c74d520c7c16a6d43ba921d06a53L126-R134) [[5]](diffhunk://#diff-499f62cb5a2d3817bed7eac3c8269667bfc8c74d520c7c16a6d43ba921d06a53L139-R167) [[6]](diffhunk://#diff-499f62cb5a2d3817bed7eac3c8269667bfc8c74d520c7c16a6d43ba921d06a53L149-R214)
* Added logic to skip creating a primary VM when the only relationship is key agreement with an Ed25519 key, in which case only the derived X25519 VM is created. [[1]](diffhunk://#diff-ff2fd81737377d8f0859516803dd6cb0a70c479e31d297814587ed7cc8a1787bL49-R66) [[2]](diffhunk://#diff-499f62cb5a2d3817bed7eac3c8269667bfc8c74d520c7c16a6d43ba921d06a53L139-R167)

### Documentation and code clarity

* Improved comments and documentation explaining the deterministic conversion from Ed25519 to X25519 for key agreement VMs, clarifying why and how the conversion is performed during both VM creation and public key listing. [[1]](diffhunk://#diff-ff2fd81737377d8f0859516803dd6cb0a70c479e31d297814587ed7cc8a1787bL125-R143) [[2]](diffhunk://#diff-499f62cb5a2d3817bed7eac3c8269667bfc8c74d520c7c16a6d43ba921d06a53L78-R86)

### Testing

* Updated and expanded tests in `did_peer_manager_test.dart` to verify the new one-to-one key-to-VM mapping logic, including cases with multiple relationships and with Ed25519 key agreement derivation. Tests now ensure that multiple purposes share a single VM where appropriate, and that Ed25519 + key agreement produces two VMs (Ed25519 and derived X25519). [[1]](diffhunk://#diff-4241db9b873ce8235c14ca43529fb4caca48b4e7dcf16ad04209db0e8c38f4cbL458-R496) [[2]](diffhunk://#diff-4241db9b873ce8235c14ca43529fb4caca48b4e7dcf16ad04209db0e8c38f4cbR823-R879)…iple relationships