### PR TITLE
fix: remove empty objects in cleanempty method

### DIFF
--- a/lib/src/util/json_util.dart
+++ b/lib/src/util/json_util.dart
@@ -366,6 +366,7 @@ Map<String, dynamic> cleanEmpty(Map<String, dynamic> input) {
   final entries = input.entries.where((entry) => switch (entry.value) {
         null => false,
         List a => a.isNotEmpty,
+        Map m => m.isNotEmpty,
         _ => true
       });
 


### PR DESCRIPTION
`cleanEmpty` method in the SSI library strips null values and empty lists, but not empty maps. 
For example, when a VC has no holder field, the mutable→immutable round-trip produces "holder": {}, then Holder.fromJson({}) throws "id property is mandatory". to fix these kind of issues remove empty objects in cleanEmpty method.