### PR TITLE
feat: enforce strict did peer0 invariants

### DIFF
--- a/lib/src/did/did_manager/did_peer_manager.dart
+++ b/lib/src/did/did_manager/did_peer_manager.dart
@@ -6,6 +6,7 @@ import '../../key_pair/public_key.dart';
 import '../../types.dart';
 import '../../utility.dart';
 import '../did_document/did_document.dart';
+import '../did_document/service_endpoint.dart';
 import '../did_peer.dart';
 import 'add_verification_method_result.dart';
 import 'did_manager.dart';
@@ -29,11 +30,55 @@ class DidPeerManager extends DidManager {
   /// [store] - The key mapping store to use for managing key relationships.
   /// [wallet] - The wallet to use for key operations.
   /// [preferredNumalgo] - The preferred numalgo (default: [DidPeerType.peer2]).
+  ///
+  /// When [preferredNumalgo] is [DidPeerType.peer0] this manager enforces
+  /// `did:peer:0` invariants — a single underlying wallet key and no service
+  /// endpoints — by rejecting operations that would violate them. This
+  /// mirrors the behavior of `DidKeyManager`, because `did:peer:0` is, per
+  /// spec, a `did:key`-equivalent encoding (one multibase-encoded key).
   DidPeerManager({
     required super.store,
     required super.wallet,
     this.preferredNumalgo = DidPeerType.peer2,
   });
+
+  @override
+  Future<AddVerificationMethodResult> addVerificationMethod(
+    String walletKeyId, {
+    Set<VerificationRelationship>? relationships,
+  }) async {
+    if (preferredNumalgo == DidPeerType.peer0) {
+      // Track wallet keys, not VMs: `did:peer:0` encodes exactly one key, but
+      // a single wallet key can legitimately back multiple VMs in the store
+      // (e.g. an Ed25519 key plus its derived X25519 key for keyAgreement).
+      // Allow re-entry for the SAME wallet key (so multi-relationship calls
+      // still work), reject any DIFFERENT wallet key.
+      final existingWalletKeys = <String>{};
+      for (final vmId in await store.verificationMethodIds) {
+        final wid = await getWalletKeyId(vmId);
+        if (wid != null) existingWalletKeys.add(wid);
+      }
+      if (existingWalletKeys.isNotEmpty &&
+          !existingWalletKeys.contains(walletKeyId)) {
+        throw SsiException(
+          message: 'did:peer:0 supports only one wallet key.',
+          code: SsiExceptionType.tooManyVerificationMethods.code,
+        );
+      }
+    }
+    return super
+        .addVerificationMethod(walletKeyId, relationships: relationships);
+  }
+
+  @override
+  Future<void> addServiceEndpoint(ServiceEndpoint endpoint) async {
+    if (preferredNumalgo == DidPeerType.peer0) {
+      throw UnsupportedError(
+          'Adding service endpoints is not supported for did:peer:0. '
+          'Use DidPeerType.peer2 to attach services.');
+    }
+    return super.addServiceEndpoint(endpoint);
+  }
 
   @override
   @protected
@@ -149,6 +194,35 @@ class DidPeerManager extends DidManager {
             PublicKey(publicKey.id, x25519PublicKeyBytes, KeyType.x25519);
       }
       verificationMethodsPubKeys.add(publicKey);
+    }
+
+    // ---- did:peer:0 fast path -------------------------------------------
+    // Per spec, `did:peer:0` encodes exactly one key. The manager guards
+    // (`addVerificationMethod`, `addServiceEndpoint`) ensure only one
+    // underlying wallet key was added and no services exist. The store may
+    // still contain a derived x25519 VM alongside the original ed25519 VM
+    // (when keyAgreement was requested for an ed25519 key); we collapse
+    // those down to the single original key here so `_resolveDidPeer0`'s
+    // `_buildEDDoc` can derive the keyAgreement entry the same way
+    // `did:key` does.
+    if (preferredNumalgo == DidPeerType.peer0 && service.isEmpty) {
+      final walletKeyToVm = <String, String>{};
+      for (final vmId in uniqueVmIds) {
+        final wid = await getWalletKeyId(vmId);
+        if (wid != null) walletKeyToVm.putIfAbsent(wid, () => vmId);
+      }
+      if (walletKeyToVm.length == 1) {
+        final walletKeyId = walletKeyToVm.keys.first;
+        final primaryKey = await wallet.getPublicKey(walletKeyId);
+        final did = DidPeer.getDid(
+          verificationMethods: [primaryKey],
+          relationships: const {
+            VerificationRelationship.authentication: [0],
+          },
+          preferredNumalgo: DidPeerType.peer0,
+        );
+        return DidPeer.resolve(did);
+      }
     }
 
     // Create a map from verification method ID to its index in the list.

--- a/lib/src/did/did_peer.dart
+++ b/lib/src/did/did_peer.dart
@@ -163,7 +163,10 @@ DidDocument _resolveDidPeer0(String did) {
       keyPart.startsWith('2J9'); // p521
 
   // x25519
-  final forKeyAgreement = keyPart.startsWith('6LS');
+  final forKeyAgreement = keyPart.startsWith('6LS') || // x25519
+      keyPart.startsWith('Dn') || // p256
+      keyPart.startsWith('82') || // p384
+      keyPart.startsWith('2J9'); // p521
 
   if (forSigning || forKeyAgreement) {
     return _buildSimpleDoc(

--- a/test/did/did_manager/did_peer_manager_test.dart
+++ b/test/did/did_manager/did_peer_manager_test.dart
@@ -803,6 +803,80 @@ void main() {
         expect(document.id, startsWith('did:peer:2'));
       });
 
+      // -----------------------------------------------------------------
+      // Default-numalgo (peer:2) no-fallback regression tests.
+      //
+      // Pre-PR (b12ef59 / upstream `DidPeer.getDid` without
+      // `preferredNumalgo`) the static encoder auto-picked `did:peer:0`
+      // whenever the input was "1 key + 0 services", regardless of intent.
+      // After flipping the default to `DidPeerType.peer2`, the manager
+      // must produce `did:peer:2` for these minimal shapes too — never
+      // silently fall back to peer:0.
+      // -----------------------------------------------------------------
+      test(
+          'default manager: 1 key + 1 relationship + 0 services -> did:peer:2 (no auto-collapse to peer:0)',
+          () async {
+        final k = await wallet.generateKey(
+            keyId: 'peer2-default-1k1r', keyType: KeyType.p256);
+        await manager.addVerificationMethod(k.id,
+            relationships: {VerificationRelationship.authentication});
+
+        final document = await manager.getDidDocument();
+        expect(document.id, startsWith('did:peer:2'));
+        expect(document.id, isNot(startsWith('did:peer:0')));
+        // The DID must encode the single key under the V (authentication)
+        // prefix — confirms we went through the peer:2 encoder.
+        expect(document.id, contains('.Vz'));
+        expect(document.verificationMethod, hasLength(1));
+        expect(document.verificationMethod[0].id, '${document.id}#key-1');
+        expect(document.authentication, hasLength(1));
+        expect(document.keyAgreement, isEmpty);
+        expect(document.service, isEmpty);
+      });
+
+      test(
+          'default manager: 1 ed25519 key + auth+keyAgreement + 0 services -> did:peer:2 with V and E entries',
+          () async {
+        // This shape would have collapsed to did:peer:0 (with did:key-style
+        // ed25519+derived-x25519 doc) under pre-PR behavior. Under the new
+        // peer:2 default it must stay as did:peer:2 with explicit V and E
+        // entries in the DID and 2 VMs in the document.
+        final k = await wallet.generateKey(
+            keyId: 'peer2-default-ed25519', keyType: KeyType.ed25519);
+        await manager.addVerificationMethod(k.id, relationships: {
+          VerificationRelationship.authentication,
+          VerificationRelationship.keyAgreement,
+        });
+
+        final document = await manager.getDidDocument();
+        expect(document.id, startsWith('did:peer:2'));
+        expect(document.id, contains('.Vz')); // authentication (ed25519)
+        expect(document.id, contains('.Ez')); // keyAgreement (derived x25519)
+        expect(document.verificationMethod, hasLength(2));
+        expect(document.authentication, hasLength(1));
+        expect(document.keyAgreement, hasLength(1));
+        expect(document.service, isEmpty);
+      });
+
+      test(
+          'default manager: 1 key + 0 relationships (key only) -> rejected, not silently peer:0',
+          () async {
+        // Empty relationship set: the key is added to verificationMethod
+        // but not assigned to any purpose. This shape would have been
+        // peer:0-eligible under pre-PR behavior; the manager now requires
+        // at least one relationship and throws — neither does it silently
+        // collapse to a relationships-less did:peer:0 document.
+        final k = await wallet.generateKey(
+            keyId: 'peer2-default-orphan', keyType: KeyType.p256);
+        await manager.addVerificationMethod(k.id, relationships: const {});
+
+        expect(
+          () => manager.getDidDocument(),
+          throwsA(isA<SsiException>().having(
+              (e) => e.code, 'code', SsiExceptionType.invalidDidDocument.code)),
+        );
+      });
+
       test(
           'generates a did:peer:2 document when a service is added, even with one auth key',
           () async {

--- a/test/did/did_manager/did_peer_manager_test.dart
+++ b/test/did/did_manager/did_peer_manager_test.dart
@@ -873,5 +873,144 @@ void main() {
         expect(resolvedDoc.toJson(), didDocument.toJson());
       });
     });
+
+    // -------------------------------------------------------------------
+    // Strict `did:peer:0` semantics: when constructed with
+    // `preferredNumalgo: DidPeerType.peer0`, the manager mirrors
+    // `DidKeyManager` invariants — single underlying wallet key, no service
+    // endpoints — and always produces a `did:peer:0` DID (never silently
+    // downgrades to `did:peer:2`).
+    // -------------------------------------------------------------------
+    group('Strict did:peer:0 semantics (preferredNumalgo: peer0)', () {
+      late DidPeerManager peer0Manager;
+
+      setUp(() async {
+        peer0Manager = DidPeerManager(
+          store: InMemoryDidStore(),
+          wallet: wallet,
+          preferredNumalgo: DidPeerType.peer0,
+        );
+        await peer0Manager.init();
+      });
+
+      test('rejects a second wallet key with tooManyVerificationMethods',
+          () async {
+        final k1 = await wallet.generateKey(
+            keyId: 'peer0-strict-key-1', keyType: KeyType.p256);
+        final k2 = await wallet.generateKey(
+            keyId: 'peer0-strict-key-2', keyType: KeyType.p256);
+
+        await peer0Manager.addVerificationMethod(k1.id,
+            relationships: {VerificationRelationship.authentication});
+
+        expect(
+          () => peer0Manager.addVerificationMethod(k2.id,
+              relationships: {VerificationRelationship.authentication}),
+          throwsA(isA<SsiException>().having((e) => e.code, 'code',
+              SsiExceptionType.tooManyVerificationMethods.code)),
+        );
+      });
+
+      test('allows re-entry for the SAME wallet key (multi-relationship adds)',
+          () async {
+        final k = await wallet.generateKey(
+            keyId: 'peer0-reentry-key', keyType: KeyType.p256);
+
+        // Two separate calls for the same wallet key must not throw.
+        await peer0Manager.addVerificationMethod(k.id,
+            relationships: {VerificationRelationship.authentication});
+        await peer0Manager.addVerificationMethod(k.id,
+            relationships: {VerificationRelationship.assertionMethod});
+
+        // Document still resolves to a peer:0 DID.
+        final doc = await peer0Manager.getDidDocument();
+        expect(doc.id, startsWith('did:peer:0'));
+      });
+
+      test('rejects addServiceEndpoint with UnsupportedError', () async {
+        final k = await wallet.generateKey(
+            keyId: 'peer0-svc-key', keyType: KeyType.p256);
+        await peer0Manager.addVerificationMethod(k.id,
+            relationships: {VerificationRelationship.authentication});
+
+        final endpoint = ServiceEndpoint(
+          id: '#service-1',
+          type: const StringServiceType('DIDCommMessaging'),
+          serviceEndpoint: const StringEndpoint('https://example.com/endpoint'),
+        );
+
+        expect(
+          () => peer0Manager.addServiceEndpoint(endpoint),
+          throwsA(isA<UnsupportedError>()),
+        );
+      });
+
+      test(
+          'getDidDocument with single ed25519 key + keyAgreement still produces did:peer:0 (mirrors did:key)',
+          () async {
+        // Single ed25519 wallet key with auth + keyAgreement: the manager
+        // creates one VM for the ed25519 key plus a derived x25519 VM.
+        // Under strict peer:0 semantics getDidDocument must collapse those
+        // back to a single-key did:peer:0 — same shape DidKeyManager would
+        // produce for the same input.
+        final k = await wallet.generateKey(
+            keyId: 'peer0-ed25519', keyType: KeyType.ed25519);
+        await peer0Manager.addVerificationMethod(k.id, relationships: {
+          VerificationRelationship.authentication,
+          VerificationRelationship.keyAgreement,
+        });
+
+        final doc = await peer0Manager.getDidDocument();
+
+        expect(doc.id, startsWith('did:peer:0z6Mk'));
+        // _buildEDDoc surfaces both the ed25519 verification key and the
+        // derived x25519 keyAgreement key.
+        expect(doc.verificationMethod, hasLength(2));
+        expect(doc.authentication, hasLength(1));
+        expect(doc.keyAgreement, hasLength(1));
+        expect(doc.keyAgreement.first.id,
+            isNot(equals(doc.authentication.first.id)));
+      });
+
+      test(
+          'getDidDocument with single p256 key + multiple relationships produces did:peer:0',
+          () async {
+        // P256 doesn't trigger ed25519→x25519 derivation; a single wallet
+        // key with multiple relationships produces multiple VMs in the
+        // store. The strict peer:0 fast path must still collapse to peer:0.
+        final k = await wallet.generateKey(
+            keyId: 'peer0-p256', keyType: KeyType.p256);
+        await peer0Manager.addVerificationMethod(k.id, relationships: {
+          VerificationRelationship.authentication,
+          VerificationRelationship.assertionMethod,
+        });
+
+        final doc = await peer0Manager.getDidDocument();
+        expect(doc.id, startsWith('did:peer:0zDn'));
+      });
+
+      test('default (peer2) manager still allows multiple keys and services',
+          () async {
+        // Sanity: the strict checks must NOT leak into the default peer2
+        // manager constructed in the outer setUp().
+        final k1 = await wallet.generateKey(
+            keyId: 'peer2-default-1', keyType: KeyType.p256);
+        final k2 = await wallet.generateKey(
+            keyId: 'peer2-default-2', keyType: KeyType.p256);
+
+        await manager.addVerificationMethod(k1.id,
+            relationships: {VerificationRelationship.authentication});
+        await manager.addVerificationMethod(k2.id,
+            relationships: {VerificationRelationship.authentication});
+        await manager.addServiceEndpoint(ServiceEndpoint(
+          id: '#service-default',
+          type: const StringServiceType('DIDCommMessaging'),
+          serviceEndpoint: const StringEndpoint('https://example.com/endpoint'),
+        ));
+
+        final doc = await manager.getDidDocument();
+        expect(doc.id, startsWith('did:peer:2'));
+      });
+    });
   });
 }

--- a/test/did/did_peer_test.dart
+++ b/test/did/did_peer_test.dart
@@ -526,6 +526,170 @@ void main() {
       expect(doc.keyAgreement, isNotEmpty);
       expect(doc.keyAgreement.first.id, isNot(equals(authId)));
     });
+
+    // ---------------------------------------------------------------------
+    // Coverage for `_resolveDidPeer0` -> `_buildSimpleDoc` keyAgreement branch.
+    // The function gates `forKeyAgreement` on the multibase prefix of the
+    // single key in the DID:
+    //   '6LS' -> x25519 (keyAgreement only)
+    //   'Dn'  -> p256   (signing + keyAgreement)
+    //   '82'  -> p384   (signing + keyAgreement)
+    //   '2J9' -> p521   (signing + keyAgreement)
+    //   'Q3s' -> secp256k1 (signing only — must NOT have keyAgreement)
+    // ---------------------------------------------------------------------
+
+    test('did:peer:0 with x25519 key resolves to keyAgreement-only doc',
+        () async {
+      // Derive a deterministic x25519 public key from an ed25519 key.
+      final ed25519Seed = Uint8List.fromList(List.generate(32, (i) => i + 7));
+      final edKeyPair =
+          Ed25519KeyPair.fromSeed(ed25519Seed, id: 'x25519-source');
+      final x25519Bytes =
+          ed25519PublicToX25519Public(edKeyPair.publicKey.bytes);
+      final x25519PubKey = PublicKey('x25519-pub', x25519Bytes, KeyType.x25519);
+
+      final did = DidPeer.getDid(
+        verificationMethods: [x25519PubKey],
+        relationships: {
+          VerificationRelationship.keyAgreement: [0],
+        },
+        preferredNumalgo: DidPeerType.peer0,
+      );
+
+      // x25519 multibase encodes with the '6LS' prefix.
+      expect(did, startsWith('did:peer:0z6LS'));
+
+      final doc = DidPeer.resolve(did);
+
+      // keyAgreement-only key: signing-side relationships must be empty.
+      expect(doc.keyAgreement, hasLength(1));
+      expect(doc.authentication, isEmpty);
+      expect(doc.assertionMethod, isEmpty);
+      expect(doc.capabilityInvocation, isEmpty);
+      expect(doc.capabilityDelegation, isEmpty);
+
+      // VM bookkeeping.
+      expect(doc.verificationMethod, hasLength(1));
+      expect(doc.verificationMethod.first.type, 'Multikey');
+      expect(doc.verificationMethod.first.controller, did);
+      expect(doc.keyAgreement.first.id, doc.verificationMethod.first.id);
+    });
+
+    test('did:peer:0 with P256 key includes keyAgreement relationship',
+        () async {
+      // Same key as the existing P256 test, but here we assert keyAgreement.
+      final seed = Uint8List.fromList(List.generate(32, (i) => i));
+      final p256KeyPair = P256KeyPair.fromSeed(seed);
+
+      final did = DidPeer.getDid(
+        verificationMethods: [p256KeyPair.publicKey],
+        relationships: {
+          VerificationRelationship.authentication: [0],
+        },
+        preferredNumalgo: DidPeerType.peer0,
+      );
+      final doc = DidPeer.resolve(did);
+
+      expect(doc.id, startsWith('did:peer:0zDn'));
+
+      // Both signing-side and keyAgreement must reference the single VM.
+      expect(doc.verificationMethod, hasLength(1));
+      final vmId = doc.verificationMethod.first.id;
+      expect(doc.authentication.first.id, vmId);
+      expect(doc.assertionMethod.first.id, vmId);
+      expect(doc.capabilityInvocation.first.id, vmId);
+      expect(doc.capabilityDelegation.first.id, vmId);
+      expect(doc.keyAgreement, hasLength(1));
+      expect(doc.keyAgreement.first.id, vmId);
+    });
+
+    test(
+        'did:peer:0 with Secp256k1 key has signing relationships only (no keyAgreement)',
+        () async {
+      final seed = Uint8List.fromList(List.generate(32, (i) => 100 + i));
+      final node = BIP32.fromSeed(seed);
+      final secp256k1KeyPair = Secp256k1KeyPair(node: node);
+
+      final did = DidPeer.getDid(
+        verificationMethods: [secp256k1KeyPair.publicKey],
+        relationships: {
+          VerificationRelationship.authentication: [0],
+        },
+        preferredNumalgo: DidPeerType.peer0,
+      );
+      final doc = DidPeer.resolve(did);
+
+      expect(doc.id, startsWith('did:peer:0zQ3s'));
+
+      // secp256k1 is signing-only: keyAgreement must remain empty.
+      expect(doc.authentication, hasLength(1));
+      expect(doc.assertionMethod, hasLength(1));
+      expect(doc.capabilityInvocation, hasLength(1));
+      expect(doc.capabilityDelegation, hasLength(1));
+      expect(doc.keyAgreement, isEmpty);
+    });
+
+    test(
+        'generateDocument for did:peer:0 with P384 key (signing + keyAgreement)',
+        () async {
+      // P384KeyPair.fromSeed has seed-dependent edge cases on some inputs;
+      // use .generate() since this test only asserts prefix + structure.
+      final (p384KeyPair, _) = P384KeyPair.generate();
+
+      final did = DidPeer.getDid(
+        verificationMethods: [p384KeyPair.publicKey],
+        relationships: {
+          VerificationRelationship.authentication: [0],
+        },
+        preferredNumalgo: DidPeerType.peer0,
+      );
+      final doc = DidPeer.resolve(did);
+
+      expect(doc.id, startsWith('did:peer:0z82'));
+
+      expect(doc.verificationMethod, hasLength(1));
+      expect(doc.verificationMethod.first.type, 'Multikey');
+      expect(doc.verificationMethod.first.controller, did);
+
+      final vmId = doc.verificationMethod.first.id;
+      expect(doc.authentication.first.id, vmId);
+      expect(doc.assertionMethod.first.id, vmId);
+      expect(doc.capabilityInvocation.first.id, vmId);
+      expect(doc.capabilityDelegation.first.id, vmId);
+      expect(doc.keyAgreement, hasLength(1));
+      expect(doc.keyAgreement.first.id, vmId);
+    });
+
+    test(
+        'generateDocument for did:peer:0 with P521 key (signing + keyAgreement)',
+        () async {
+      // P521KeyPair.fromSeed has seed-dependent edge cases on some inputs;
+      // use .generate() since this test only asserts prefix + structure.
+      final (p521KeyPair, _) = P521KeyPair.generate();
+
+      final did = DidPeer.getDid(
+        verificationMethods: [p521KeyPair.publicKey],
+        relationships: {
+          VerificationRelationship.authentication: [0],
+        },
+        preferredNumalgo: DidPeerType.peer0,
+      );
+      final doc = DidPeer.resolve(did);
+
+      expect(doc.id, startsWith('did:peer:0z2J9'));
+
+      expect(doc.verificationMethod, hasLength(1));
+      expect(doc.verificationMethod.first.type, 'Multikey');
+      expect(doc.verificationMethod.first.controller, did);
+
+      final vmId = doc.verificationMethod.first.id;
+      expect(doc.authentication.first.id, vmId);
+      expect(doc.assertionMethod.first.id, vmId);
+      expect(doc.capabilityInvocation.first.id, vmId);
+      expect(doc.capabilityDelegation.first.id, vmId);
+      expect(doc.keyAgreement, hasLength(1));
+      expect(doc.keyAgreement.first.id, vmId);
+    });
   });
 
   test('did:key and did:peer:0 have equivalent key fragments', () async {


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the DID and credential management logic, with a focus on standards compliance, deterministic ID generation, and proper handling of DID method variants. The most significant changes are the addition of strict support for `did:peer:0` in `DidPeerManager`, improved JWK thumbprint-based verification method IDs for `did:web`, and various fixes to ensure correct key usage and relationships.

**DID Peer Manager: `did:peer:0` strict mode and resolution improvements**
* Added a `preferredNumalgo` option to `DidPeerManager`, enabling strict enforcement of `did:peer:0` rules (single wallet key, no services) and fast-path resolution for peer0 DIDs. [[1]](diffhunk://#diff-ff2fd81737377d8f0859516803dd6cb0a70c479e31d297814587ed7cc8a1787bR21-R82) [[2]](diffhunk://#diff-ff2fd81737377d8f0859516803dd6cb0a70c479e31d297814587ed7cc8a1787bR199-R227)
* Updated the DID peer resolution logic to properly handle `did:peer:0` and pass the preferred numalgo through to DID construction.

**DID Web Manager: Deterministic JWK thumbprint-based VM IDs and key handling**
* Changed `buildVerificationMethodId` in `DidWebManager` to use the JWK thumbprint (RFC 7638) of the public key for deterministic, standards-compliant verification method IDs.
* Refactored verification method creation to ensure correct handling of Ed25519/X25519 key derivation and consistent DID document generation. [[1]](diffhunk://#diff-499f62cb5a2d3817bed7eac3c8269667bfc8c74d520c7c16a6d43ba921d06a53L126-R142) [[2]](diffhunk://#diff-499f62cb5a2d3817bed7eac3c8269667bfc8c74d520c7c16a6d43ba921d06a53L139-R175) [[3]](diffhunk://#diff-499f62cb5a2d3817bed7eac3c8269667bfc8c74d520c7c16a6d43ba921d06a53L149-R222)

**Credential and proof generation: Consistent use of `didKeyId`**
* Updated all credential and proof generation logic to use `signer.didKeyId` instead of `signer.keyId` for JWT headers, proof verification methods, and related fields, ensuring correct DID-based key references. [[1]](diffhunk://#diff-c60c6101aa264de4fafd9abb3d704555736e7a88b432e8eb36bdea9eb30785a3L32-R32) [[2]](diffhunk://#diff-5a5866ddc37fe8af5e2d569ccdf1c7dd6995c80dff3ab68f7cc0811b9602badcL61-R61) [[3]](diffhunk://#diff-5a5866ddc37fe8af5e2d569ccdf1c7dd6995c80dff3ab68f7cc0811b9602badcL98-R98) [[4]](diffhunk://#diff-31cb88d8a6108e0cb402a48cc3918e6586d25554180c80a397b318bd2a6e8304L75-R75) [[5]](diffhunk://#diff-31cb88d8a6108e0cb402a48cc3918e6586d25554180c80a397b318bd2a6e8304L97-R97) [[6]](diffhunk://#diff-b3615fbbf90070d1f50541715e077a780d91c2b9ae0aa91c170f536b18552f3bL69-R69) [[7]](diffhunk://#diff-b3615fbbf90070d1f50541715e077a780d91c2b9ae0aa91c170f536b18552f3bL91-R91) [[8]](diffhunk://#diff-ef847eca98cc3b206deb55de824d5035197d115032f0709f6975118d7c3fbb6bL50-R50) [[9]](diffhunk://#diff-ef847eca98cc3b206deb55de824d5035197d115032f0709f6975118d7c3fbb6bL70-R70)

**DID Peer and Web: Standards compliance and bugfixes**
* Fixed the construction of verification method IDs in `did:peer:2` resolution to use the full DID URL, not just a fragment.
* Updated the `did:peer:0` resolver to recognize additional key types for key agreement, improving compatibility.

**Other improvements**
* Improved issuer field handling in JWT credential payloads to ensure the correct issuer value is always set, even when the issuer is a map.
* Added missing imports and documentation for clarity and maintainability. [[1]](diffhunk://#diff-ff2fd81737377d8f0859516803dd6cb0a70c479e31d297814587ed7cc8a1787bR9) [[2]](diffhunk://#diff-499f62cb5a2d3817bed7eac3c8269667bfc8c74d520c7c16a6d43ba921d06a53R1-R3) [[3]](diffhunk://#diff-499f62cb5a2d3817bed7eac3c8269667bfc8c74d520c7c16a6d43ba921d06a53R13)

These changes collectively improve standards compliance, deterministic behavior, and robustness in the handling of DIDs and credentials.