### PR TITLE
feat!: did peer strict peer0 v2

### DIFF
--- a/lib/src/did/did_manager/did_peer_manager.dart
+++ b/lib/src/did/did_manager/did_peer_manager.dart
@@ -17,13 +17,22 @@ import 'verification_relationship.dart';
 /// which supports multiple keys with separate authentication and
 /// key agreement purposes, as well as service endpoints.
 class DidPeerManager extends DidManager {
+  /// The preferred numalgo for DID generation.
+  ///
+  /// - [DidPeerType.peer2] (default): always produces `did:peer:2`.
+  /// - [DidPeerType.peer0]: produces `did:peer:0` when possible
+  ///   (single VM, no services); falls back to `did:peer:2` otherwise.
+  final DidPeerType preferredNumalgo;
+
   /// Creates a new DID Peer manager instance.
   ///
   /// [store] - The key mapping store to use for managing key relationships.
   /// [wallet] - The wallet to use for key operations.
+  /// [preferredNumalgo] - The preferred numalgo (default: [DidPeerType.peer2]).
   DidPeerManager({
     required super.store,
     required super.wallet,
+    this.preferredNumalgo = DidPeerType.peer2,
   });
 
   @override
@@ -166,6 +175,7 @@ class DidPeerManager extends DidManager {
       verificationMethods: verificationMethodsPubKeys,
       relationships: relationshipIndexes,
       serviceEndpoints: service.toList(),
+      preferredNumalgo: preferredNumalgo,
     );
 
     // For did:peer:0, the resolution logic is simple and handles key derivation.

--- a/lib/src/did/did_manager/did_peer_manager.dart
+++ b/lib/src/did/did_manager/did_peer_manager.dart
@@ -6,6 +6,7 @@ import '../../key_pair/public_key.dart';
 import '../../types.dart';
 import '../../utility.dart';
 import '../did_document/did_document.dart';
+import '../did_document/service_endpoint.dart';
 import '../did_peer.dart';
 import 'add_verification_method_result.dart';
 import 'did_manager.dart';
@@ -29,11 +30,55 @@ class DidPeerManager extends DidManager {
   /// [store] - The key mapping store to use for managing key relationships.
   /// [wallet] - The wallet to use for key operations.
   /// [preferredNumalgo] - The preferred numalgo (default: [DidPeerType.peer2]).
+  ///
+  /// When [preferredNumalgo] is [DidPeerType.peer0] this manager enforces
+  /// `did:peer:0` invariants — a single underlying wallet key and no service
+  /// endpoints — by rejecting operations that would violate them. This
+  /// mirrors the behavior of `DidKeyManager`, because `did:peer:0` is, per
+  /// spec, a `did:key`-equivalent encoding (one multibase-encoded key).
   DidPeerManager({
     required super.store,
     required super.wallet,
     this.preferredNumalgo = DidPeerType.peer2,
   });
+
+  @override
+  Future<AddVerificationMethodResult> addVerificationMethod(
+    String walletKeyId, {
+    Set<VerificationRelationship>? relationships,
+  }) async {
+    if (preferredNumalgo == DidPeerType.peer0) {
+      // Track wallet keys, not VMs: `did:peer:0` encodes exactly one key, but
+      // a single wallet key can legitimately back multiple VMs in the store
+      // (e.g. an Ed25519 key plus its derived X25519 key for keyAgreement).
+      // Allow re-entry for the SAME wallet key (so multi-relationship calls
+      // still work), reject any DIFFERENT wallet key.
+      final existingWalletKeys = <String>{};
+      for (final vmId in await store.verificationMethodIds) {
+        final wid = await getWalletKeyId(vmId);
+        if (wid != null) existingWalletKeys.add(wid);
+      }
+      if (existingWalletKeys.isNotEmpty &&
+          !existingWalletKeys.contains(walletKeyId)) {
+        throw SsiException(
+          message: 'did:peer:0 supports only one wallet key.',
+          code: SsiExceptionType.tooManyVerificationMethods.code,
+        );
+      }
+    }
+    return super
+        .addVerificationMethod(walletKeyId, relationships: relationships);
+  }
+
+  @override
+  Future<void> addServiceEndpoint(ServiceEndpoint endpoint) async {
+    if (preferredNumalgo == DidPeerType.peer0) {
+      throw UnsupportedError(
+          'Adding service endpoints is not supported for did:peer:0. '
+          'Use DidPeerType.peer2 to attach services.');
+    }
+    return super.addServiceEndpoint(endpoint);
+  }
 
   @override
   @protected
@@ -149,6 +194,35 @@ class DidPeerManager extends DidManager {
             PublicKey(publicKey.id, x25519PublicKeyBytes, KeyType.x25519);
       }
       verificationMethodsPubKeys.add(publicKey);
+    }
+
+    // ---- did:peer:0 fast path -------------------------------------------
+    // Per spec, `did:peer:0` encodes exactly one key. The manager guards
+    // (`addVerificationMethod`, `addServiceEndpoint`) ensure only one
+    // underlying wallet key was added and no services exist. The store may
+    // still contain a derived x25519 VM alongside the original ed25519 VM
+    // (when keyAgreement was requested for an ed25519 key); we collapse
+    // those down to the single original key here so `_resolveDidPeer0`'s
+    // `_buildEDDoc` can derive the keyAgreement entry the same way
+    // `did:key` does.
+    if (preferredNumalgo == DidPeerType.peer0 && service.isEmpty) {
+      final walletKeyToVm = <String, String>{};
+      for (final vmId in uniqueVmIds) {
+        final wid = await getWalletKeyId(vmId);
+        if (wid != null) walletKeyToVm.putIfAbsent(wid, () => vmId);
+      }
+      if (walletKeyToVm.length == 1) {
+        final walletKeyId = walletKeyToVm.keys.first;
+        final primaryKey = await wallet.getPublicKey(walletKeyId);
+        final did = DidPeer.getDid(
+          verificationMethods: [primaryKey],
+          relationships: const {
+            VerificationRelationship.authentication: [0],
+          },
+          preferredNumalgo: DidPeerType.peer0,
+        );
+        return DidPeer.resolve(did);
+      }
     }
 
     // Create a map from verification method ID to its index in the list.

--- a/lib/src/did/did_manager/did_peer_manager.dart
+++ b/lib/src/did/did_manager/did_peer_manager.dart
@@ -73,9 +73,11 @@ class DidPeerManager extends DidManager {
   @override
   Future<void> addServiceEndpoint(ServiceEndpoint endpoint) async {
     if (preferredNumalgo == DidPeerType.peer0) {
-      throw UnsupportedError(
-          'Adding service endpoints is not supported for did:peer:0. '
-          'Use DidPeerType.peer2 to attach services.');
+      throw SsiException(
+        message: 'Adding service endpoints is not supported for did:peer:0. '
+            'Use DidPeerType.peer2 to attach services.',
+        code: SsiExceptionType.unsupportedDidOperation.code,
+      );
     }
     return super.addServiceEndpoint(endpoint);
   }
@@ -207,9 +209,14 @@ class DidPeerManager extends DidManager {
     // `did:key` does.
     if (preferredNumalgo == DidPeerType.peer0 && service.isEmpty) {
       final walletKeyToVm = <String, String>{};
-      for (final vmId in uniqueVmIds) {
-        final wid = await getWalletKeyId(vmId);
-        if (wid != null) walletKeyToVm.putIfAbsent(wid, () => vmId);
+      final walletKeyIds = await Future.wait(
+        uniqueVmIds.map(getWalletKeyId),
+      );
+      for (var i = 0; i < uniqueVmIds.length; i++) {
+        final wid = walletKeyIds[i];
+        if (wid != null) {
+          walletKeyToVm.putIfAbsent(wid, () => uniqueVmIds[i]);
+        }
       }
       if (walletKeyToVm.length == 1) {
         final walletKeyId = walletKeyToVm.keys.first;

--- a/lib/src/did/did_peer.dart
+++ b/lib/src/did/did_peer.dart
@@ -386,6 +386,9 @@ class DidPeer {
   /// [verificationMethods] The list of all public keys in the document.
   /// [relationships] A map defining which keys are used for which purpose.
   /// [serviceEndpoints] - Optional list of service endpoints.
+  /// [preferredNumalgo] - Preferred numalgo. When [DidPeerType.peer0],
+  ///   produces `did:peer:0` if there is a single key and no services.
+  ///   When [DidPeerType.peer2] (default), always produces `did:peer:2`.
   ///
   /// Returns the DID as [String].
   ///
@@ -394,6 +397,7 @@ class DidPeer {
     required List<PublicKey> verificationMethods,
     Map<VerificationRelationship, List<int>>? relationships,
     List<ServiceEndpoint>? serviceEndpoints,
+    DidPeerType preferredNumalgo = DidPeerType.peer2,
   }) {
     if (verificationMethods.isEmpty) {
       throw SsiException(
@@ -405,7 +409,9 @@ class DidPeer {
     final rels = relationships ?? {};
 
     // did:peer:0 is for a single key (equivalent to did:key).
-    final isDid0 = verificationMethods.length == 1 &&
+    // Only used when explicitly preferred AND conditions are met.
+    final isDid0 = preferredNumalgo == DidPeerType.peer0 &&
+        verificationMethods.length == 1 &&
         (serviceEndpoints == null || serviceEndpoints.isEmpty);
 
     if (isDid0) {

--- a/lib/src/exceptions/ssi_exception_type.dart
+++ b/lib/src/exceptions/ssi_exception_type.dart
@@ -66,6 +66,10 @@ enum SsiExceptionType {
   /// Too many verification methods
   tooManyVerificationMethods(code: 'too_many_verification_methods'),
 
+  /// The requested operation is not supported for the selected DID
+  /// configuration (e.g. attaching a service endpoint to did:peer:0).
+  unsupportedDidOperation(code: 'unsupported_did_operation'),
+
   /// Invalid key type
   invalidKeyType(code: 'invalid_key_type'),
 

--- a/test/did/did_manager/did_peer_manager_test.dart
+++ b/test/did/did_manager/did_peer_manager_test.dart
@@ -280,7 +280,10 @@ void main() {
         // Assert
         expect(docBefore.id, startsWith('did:peer:2'));
         expect(docBefore.service.length, 1);
-        expect(docAfter.id, startsWith('did:peer:0'));
+        // With the default `preferredNumalgo: DidPeerType.peer2`, removing
+        // the service endpoint keeps the DID as did:peer:2 (no auto-collapse
+        // to did:peer:0). See PLAN-did-peer-multi-key.md.
+        expect(docAfter.id, startsWith('did:peer:2'));
         expect(docAfter.service.length, 0);
       });
 
@@ -586,8 +589,10 @@ void main() {
         // Assert
         expect(signer.keyId, equals('${signer.did}$vmId'));
         expect(signer.signatureScheme, isNotNull);
-        expect(signer.did,
-            startsWith('did:peer:0')); // Single auth key generates peer:0
+        expect(
+          signer.did,
+          startsWith('did:peer:2'),
+        ); // Default preferredNumalgo is peer2.
       });
 
       test('should specify signature scheme for signer', () async {
@@ -613,12 +618,20 @@ void main() {
       test(
           'normalizes fragment-only verificationMethodId to full DID URL and uses full ID in proofs',
           () async {
+        // Opt into peer:0 explicitly (default is peer:2). See PLAN-did-peer-multi-key.md.
+        final peer0Manager = DidPeerManager(
+          store: InMemoryDidStore(),
+          wallet: wallet,
+          preferredNumalgo: DidPeerType.peer0,
+        );
+        await peer0Manager.init();
+
         final key = await wallet.generateKey(keyType: KeyType.ed25519);
-        final result = await manager.addVerificationMethod(key.id,
+        final result = await peer0Manager.addVerificationMethod(key.id,
             relationships: {VerificationRelationship.authentication});
         final vmIdFragment = result.verificationMethodId; // e.g. '#key-1'
 
-        final signer = await manager.getSigner(vmIdFragment);
+        final signer = await peer0Manager.getSigner(vmIdFragment);
 
         // signer.keyId should now be fully qualified DID + fragment
         expect(signer.keyId, '${signer.did}$vmIdFragment');
@@ -676,14 +689,22 @@ void main() {
     group('Key retrieval', () {
       test('should retrieve DID key pair', () async {
         // Arrange
+        // Opt into peer:0 explicitly (default is peer:2). See PLAN-did-peer-multi-key.md.
+        final peer0Manager = DidPeerManager(
+          store: InMemoryDidStore(),
+          wallet: wallet,
+          preferredNumalgo: DidPeerType.peer0,
+        );
+        await peer0Manager.init();
+
         final key = await wallet.generateKey(
             keyId: 'retrieve-key', keyType: KeyType.p256);
-        final result = await manager.addVerificationMethod(key.id,
+        final result = await peer0Manager.addVerificationMethod(key.id,
             relationships: {VerificationRelationship.authentication});
         final vmId = result.verificationMethodId;
 
         // Act
-        final didKeyPair = await manager.getKey(vmId);
+        final didKeyPair = await peer0Manager.getKey(vmId);
 
         // Assert
         expect(didKeyPair.keyPair.id, equals(key.id));
@@ -723,6 +744,14 @@ void main() {
 
     group('DID generation', () {
       test('generates a valid did:peer:0 document', () async {
+        // Opt into peer:0 explicitly (default is peer:2). See PLAN-did-peer-multi-key.md.
+        final manager = DidPeerManager(
+          store: InMemoryDidStore(),
+          wallet: wallet,
+          preferredNumalgo: DidPeerType.peer0,
+        );
+        await manager.init();
+
         // Generate key
         final authKey = await wallet.generateKey(keyType: KeyType.ed25519);
 
@@ -812,9 +841,11 @@ void main() {
         final seed = Uint8List(32); // A dummy seed for testing
         final bip32Wallet = Bip32Wallet.fromSeed(seed);
         final store = InMemoryDidStore();
+        // Opt into peer:0 explicitly (default is peer:2). See PLAN-did-peer-multi-key.md.
         final manager = DidPeerManager(
           store: store,
           wallet: bip32Wallet,
+          preferredNumalgo: DidPeerType.peer0,
         );
         const derivationPath = "m/44'/0'/0'/0/0";
         final authKey = await bip32Wallet.generateKey(keyId: derivationPath);

--- a/test/did/did_manager/did_peer_manager_test.dart
+++ b/test/did/did_manager/did_peer_manager_test.dart
@@ -803,6 +803,80 @@ void main() {
         expect(document.id, startsWith('did:peer:2'));
       });
 
+      // -----------------------------------------------------------------
+      // Default-numalgo (peer:2) no-fallback regression tests.
+      //
+      // Pre-PR (b12ef59 / upstream `DidPeer.getDid` without
+      // `preferredNumalgo`) the static encoder auto-picked `did:peer:0`
+      // whenever the input was "1 key + 0 services", regardless of intent.
+      // After flipping the default to `DidPeerType.peer2`, the manager
+      // must produce `did:peer:2` for these minimal shapes too — never
+      // silently fall back to peer:0.
+      // -----------------------------------------------------------------
+      test(
+          'default manager: 1 key + 1 relationship + 0 services -> did:peer:2 (no auto-collapse to peer:0)',
+          () async {
+        final k = await wallet.generateKey(
+            keyId: 'peer2-default-1k1r', keyType: KeyType.p256);
+        await manager.addVerificationMethod(k.id,
+            relationships: {VerificationRelationship.authentication});
+
+        final document = await manager.getDidDocument();
+        expect(document.id, startsWith('did:peer:2'));
+        expect(document.id, isNot(startsWith('did:peer:0')));
+        // The DID must encode the single key under the V (authentication)
+        // prefix — confirms we went through the peer:2 encoder.
+        expect(document.id, contains('.Vz'));
+        expect(document.verificationMethod, hasLength(1));
+        expect(document.verificationMethod[0].id, '${document.id}#key-1');
+        expect(document.authentication, hasLength(1));
+        expect(document.keyAgreement, isEmpty);
+        expect(document.service, isEmpty);
+      });
+
+      test(
+          'default manager: 1 ed25519 key + auth+keyAgreement + 0 services -> did:peer:2 with V and E entries',
+          () async {
+        // This shape would have collapsed to did:peer:0 (with did:key-style
+        // ed25519+derived-x25519 doc) under pre-PR behavior. Under the new
+        // peer:2 default it must stay as did:peer:2 with explicit V and E
+        // entries in the DID and 2 VMs in the document.
+        final k = await wallet.generateKey(
+            keyId: 'peer2-default-ed25519', keyType: KeyType.ed25519);
+        await manager.addVerificationMethod(k.id, relationships: {
+          VerificationRelationship.authentication,
+          VerificationRelationship.keyAgreement,
+        });
+
+        final document = await manager.getDidDocument();
+        expect(document.id, startsWith('did:peer:2'));
+        expect(document.id, contains('.Vz')); // authentication (ed25519)
+        expect(document.id, contains('.Ez')); // keyAgreement (derived x25519)
+        expect(document.verificationMethod, hasLength(2));
+        expect(document.authentication, hasLength(1));
+        expect(document.keyAgreement, hasLength(1));
+        expect(document.service, isEmpty);
+      });
+
+      test(
+          'default manager: 1 key + 0 relationships (key only) -> rejected, not silently peer:0',
+          () async {
+        // Empty relationship set: the key is added to verificationMethod
+        // but not assigned to any purpose. This shape would have been
+        // peer:0-eligible under pre-PR behavior; the manager now requires
+        // at least one relationship and throws — neither does it silently
+        // collapse to a relationships-less did:peer:0 document.
+        final k = await wallet.generateKey(
+            keyId: 'peer2-default-orphan', keyType: KeyType.p256);
+        await manager.addVerificationMethod(k.id, relationships: const {});
+
+        expect(
+          () => manager.getDidDocument(),
+          throwsA(isA<SsiException>().having(
+              (e) => e.code, 'code', SsiExceptionType.invalidDidDocument.code)),
+        );
+      });
+
       test(
           'generates a did:peer:2 document when a service is added, even with one auth key',
           () async {

--- a/test/did/did_manager/did_peer_manager_test.dart
+++ b/test/did/did_manager/did_peer_manager_test.dart
@@ -873,5 +873,144 @@ void main() {
         expect(resolvedDoc.toJson(), didDocument.toJson());
       });
     });
+
+    // -------------------------------------------------------------------
+    // Strict `did:peer:0` semantics: when constructed with
+    // `preferredNumalgo: DidPeerType.peer0`, the manager mirrors
+    // `DidKeyManager` invariants — single underlying wallet key, no service
+    // endpoints — and always produces a `did:peer:0` DID (never silently
+    // downgrades to `did:peer:2`).
+    // -------------------------------------------------------------------
+    group('Strict did:peer:0 semantics (preferredNumalgo: peer0)', () {
+      late DidPeerManager peer0Manager;
+
+      setUp(() async {
+        peer0Manager = DidPeerManager(
+          store: InMemoryDidStore(),
+          wallet: wallet,
+          preferredNumalgo: DidPeerType.peer0,
+        );
+        await peer0Manager.init();
+      });
+
+      test('rejects a second wallet key with tooManyVerificationMethods',
+          () async {
+        final k1 = await wallet.generateKey(
+            keyId: 'peer0-strict-key-1', keyType: KeyType.p256);
+        final k2 = await wallet.generateKey(
+            keyId: 'peer0-strict-key-2', keyType: KeyType.p256);
+
+        await peer0Manager.addVerificationMethod(k1.id,
+            relationships: {VerificationRelationship.authentication});
+
+        expect(
+          () => peer0Manager.addVerificationMethod(k2.id,
+              relationships: {VerificationRelationship.authentication}),
+          throwsA(isA<SsiException>().having((e) => e.code, 'code',
+              SsiExceptionType.tooManyVerificationMethods.code)),
+        );
+      });
+
+      test('allows re-entry for the SAME wallet key (multi-relationship adds)',
+          () async {
+        final k = await wallet.generateKey(
+            keyId: 'peer0-reentry-key', keyType: KeyType.p256);
+
+        // Two separate calls for the same wallet key must not throw.
+        await peer0Manager.addVerificationMethod(k.id,
+            relationships: {VerificationRelationship.authentication});
+        await peer0Manager.addVerificationMethod(k.id,
+            relationships: {VerificationRelationship.assertionMethod});
+
+        // Document still resolves to a peer:0 DID.
+        final doc = await peer0Manager.getDidDocument();
+        expect(doc.id, startsWith('did:peer:0'));
+      });
+
+      test('rejects addServiceEndpoint with UnsupportedError', () async {
+        final k = await wallet.generateKey(
+            keyId: 'peer0-svc-key', keyType: KeyType.p256);
+        await peer0Manager.addVerificationMethod(k.id,
+            relationships: {VerificationRelationship.authentication});
+
+        final endpoint = ServiceEndpoint(
+          id: '#service-1',
+          type: const StringServiceType('DIDCommMessaging'),
+          serviceEndpoint: const StringEndpoint('https://example.com/endpoint'),
+        );
+
+        expect(
+          () => peer0Manager.addServiceEndpoint(endpoint),
+          throwsA(isA<UnsupportedError>()),
+        );
+      });
+
+      test(
+          'getDidDocument with single ed25519 key + keyAgreement still produces did:peer:0 (mirrors did:key)',
+          () async {
+        // Single ed25519 wallet key with auth + keyAgreement: the manager
+        // creates one VM for the ed25519 key plus a derived x25519 VM.
+        // Under strict peer:0 semantics getDidDocument must collapse those
+        // back to a single-key did:peer:0 — same shape DidKeyManager would
+        // produce for the same input.
+        final k = await wallet.generateKey(
+            keyId: 'peer0-ed25519', keyType: KeyType.ed25519);
+        await peer0Manager.addVerificationMethod(k.id, relationships: {
+          VerificationRelationship.authentication,
+          VerificationRelationship.keyAgreement,
+        });
+
+        final doc = await peer0Manager.getDidDocument();
+
+        expect(doc.id, startsWith('did:peer:0z6Mk'));
+        // _buildEDDoc surfaces both the ed25519 verification key and the
+        // derived x25519 keyAgreement key.
+        expect(doc.verificationMethod, hasLength(2));
+        expect(doc.authentication, hasLength(1));
+        expect(doc.keyAgreement, hasLength(1));
+        expect(doc.keyAgreement.first.id,
+            isNot(equals(doc.authentication.first.id)));
+      });
+
+      test(
+          'getDidDocument with single p256 key + multiple relationships produces did:peer:0',
+          () async {
+        // P256 doesn't trigger ed25519→x25519 derivation; a single wallet
+        // key with multiple relationships produces multiple VMs in the
+        // store. The strict peer:0 fast path must still collapse to peer:0.
+        final k = await wallet.generateKey(
+            keyId: 'peer0-p256', keyType: KeyType.p256);
+        await peer0Manager.addVerificationMethod(k.id, relationships: {
+          VerificationRelationship.authentication,
+          VerificationRelationship.assertionMethod,
+        });
+
+        final doc = await peer0Manager.getDidDocument();
+        expect(doc.id, startsWith('did:peer:0zDn'));
+      });
+
+      test('default (peer2) manager still allows multiple keys and services',
+          () async {
+        // Sanity: the strict checks must NOT leak into the default peer2
+        // manager constructed in the outer setUp().
+        final k1 = await wallet.generateKey(
+            keyId: 'peer2-default-1', keyType: KeyType.p256);
+        final k2 = await wallet.generateKey(
+            keyId: 'peer2-default-2', keyType: KeyType.p256);
+
+        await manager.addVerificationMethod(k1.id,
+            relationships: {VerificationRelationship.authentication});
+        await manager.addVerificationMethod(k2.id,
+            relationships: {VerificationRelationship.authentication});
+        await manager.addServiceEndpoint(ServiceEndpoint(
+          id: '#service-default',
+          type: const StringServiceType('DIDCommMessaging'),
+          serviceEndpoint: const StringEndpoint('https://example.com/endpoint'),
+        ));
+
+        final doc = await manager.getDidDocument();
+        expect(doc.id, startsWith('did:peer:2'));
+      });
+    });
   });
 }

--- a/test/did/did_manager/did_peer_manager_test.dart
+++ b/test/did/did_manager/did_peer_manager_test.dart
@@ -1001,7 +1001,7 @@ void main() {
         expect(doc.id, startsWith('did:peer:0'));
       });
 
-      test('rejects addServiceEndpoint with UnsupportedError', () async {
+      test('rejects addServiceEndpoint with SsiException', () async {
         final k = await wallet.generateKey(
             keyId: 'peer0-svc-key', keyType: KeyType.p256);
         await peer0Manager.addVerificationMethod(k.id,
@@ -1015,7 +1015,8 @@ void main() {
 
         expect(
           () => peer0Manager.addServiceEndpoint(endpoint),
-          throwsA(isA<UnsupportedError>()),
+          throwsA(isA<SsiException>().having((e) => e.code, 'code',
+              SsiExceptionType.unsupportedDidOperation.code)),
         );
       });
 

--- a/test/did/did_peer_test.dart
+++ b/test/did/did_peer_test.dart
@@ -36,6 +36,7 @@ void main() {
         relationships: {
           VerificationRelationship.authentication: [0]
         },
+        preferredNumalgo: DidPeerType.peer0,
       );
       final doc = DidPeer.resolve(did);
       final actualDid = doc.id;
@@ -60,6 +61,7 @@ void main() {
         relationships: {
           VerificationRelationship.authentication: [0]
         },
+        preferredNumalgo: DidPeerType.peer0,
       );
 
       expect(actualDid, expectedDid);
@@ -349,7 +351,7 @@ void main() {
         p256KeyPair.publicKey
       ], relationships: {
         VerificationRelationship.authentication: [0],
-      });
+      }, preferredNumalgo: DidPeerType.peer0);
       final doc = DidPeer.resolve(did);
 
       final actualDid = doc.id;
@@ -393,7 +395,7 @@ void main() {
         secp256k1KeyPair.publicKey
       ], relationships: {
         VerificationRelationship.authentication: [0],
-      });
+      }, preferredNumalgo: DidPeerType.peer0);
       final doc = DidPeer.resolve(did);
       final actualDid = doc.id;
       final resolvedDidDocument = DidPeer.resolve(actualDid);
@@ -501,6 +503,7 @@ void main() {
           VerificationRelationship.assertionMethod: [0],
           VerificationRelationship.keyAgreement: [0],
         },
+        preferredNumalgo: DidPeerType.peer0,
       );
 
       // Should still pick numalgo0
@@ -550,6 +553,7 @@ void main() {
         relationships: {
           VerificationRelationship.keyAgreement: [0],
         },
+        preferredNumalgo: DidPeerType.peer0,
       );
 
       // x25519 multibase encodes with the '6LS' prefix.
@@ -582,6 +586,7 @@ void main() {
         relationships: {
           VerificationRelationship.authentication: [0],
         },
+        preferredNumalgo: DidPeerType.peer0,
       );
       final doc = DidPeer.resolve(did);
 
@@ -610,6 +615,7 @@ void main() {
         relationships: {
           VerificationRelationship.authentication: [0],
         },
+        preferredNumalgo: DidPeerType.peer0,
       );
       final doc = DidPeer.resolve(did);
 
@@ -635,6 +641,7 @@ void main() {
         relationships: {
           VerificationRelationship.authentication: [0],
         },
+        preferredNumalgo: DidPeerType.peer0,
       );
       final doc = DidPeer.resolve(did);
 
@@ -665,6 +672,7 @@ void main() {
         relationships: {
           VerificationRelationship.authentication: [0],
         },
+        preferredNumalgo: DidPeerType.peer0,
       );
       final doc = DidPeer.resolve(did);
 
@@ -690,7 +698,10 @@ void main() {
     final pubKey = keyPair.publicKey;
 
     final didKey = DidKey.getDid(pubKey);
-    final peer0 = DidPeer.getDid(verificationMethods: [pubKey]);
+    final peer0 = DidPeer.getDid(
+      verificationMethods: [pubKey],
+      preferredNumalgo: DidPeerType.peer0,
+    );
 
     final didKeyDoc = DidKey.resolve(didKey);
     final peerDoc = DidPeer.resolve(peer0);


### PR DESCRIPTION
BREAKING(4.X.X release candidate)

BREAKING CHANGE: 
- introduced `preferredNumalgo` (`did:peer:2` by default)
- deduplication of Verification Method for `did:peer:0` as per spec(following `did:key` behavior)

This pull request introduces a formal mechanism for selecting the DID peer algorithm ("numalgo") when generating `did:peer` identifiers, providing strict support for both `did:peer:2` (default) and `did:peer:0` semantics. The changes ensure that `did:peer:0` is only produced when explicitly requested and only under its strict invariants (single key, no services), while `did:peer:2` remains the default and supports multiple keys and service endpoints. The update also includes comprehensive tests to verify correct behavior for both modes and prevent unintentional fallback to `did:peer:0`.

**DID Peer Algorithm Selection and Enforcement**

* Added a `preferredNumalgo` parameter to `DidPeerManager`, defaulting to `DidPeerType.peer2`. When set to `DidPeerType.peer0`, the manager enforces strict `did:peer:0` invariants (single wallet key, no service endpoints) and throws exceptions if violated. (`lib/src/did/did_manager/did_peer_manager.dart`)
* Updated `DidPeer.getDid` to accept a `preferredNumalgo` parameter. Now, `did:peer:0` is only generated if `preferredNumalgo` is set to `peer0` and the input meets the constraints; otherwise, it always produces `did:peer:2`. (`lib/src/did/did_peer.dart`) (F9928bebL394R409)

**Manager and Encoder Logic Updates**

* Modified `DidPeerManager.getDidDocument` to use the new `preferredNumalgo` logic and added a fast path for collapsing to `did:peer:0` when appropriate. (`lib/src/did/did_manager/did_peer_manager.dart`) [[1]](diffhunk://#diff-ff2fd81737377d8f0859516803dd6cb0a70c479e31d297814587ed7cc8a1787bR199-R227) [[2]](diffhunk://#diff-ff2fd81737377d8f0859516803dd6cb0a70c479e31d297814587ed7cc8a1787bR252)

**Test Suite Enhancements**

* Updated and expanded tests to:
  - Explicitly test both `did:peer:2` (default) and strict `did:peer:0` scenarios
  - Ensure no silent fallback to `did:peer:0` in the default mode
  - Verify that strict `did:peer:0` mode rejects multiple keys and service endpoints, but allows multiple relationships for the same key
  - Add regression tests for pre-PR and post-PR behaviors (`test/did/did_manager/did_peer_manager_test.dart`) [[1]](diffhunk://#diff-4241db9b873ce8235c14ca43529fb4caca48b4e7dcf16ad04209db0e8c38f4cbL283-R286) [[2]](diffhunk://#diff-4241db9b873ce8235c14ca43529fb4caca48b4e7dcf16ad04209db0e8c38f4cbL589-R595) [[3]](diffhunk://#diff-4241db9b873ce8235c14ca43529fb4caca48b4e7dcf16ad04209db0e8c38f4cbR621-R634) [[4]](diffhunk://#diff-4241db9b873ce8235c14ca43529fb4caca48b4e7dcf16ad04209db0e8c38f4cbR692-R707) [[5]](diffhunk://#diff-4241db9b873ce8235c14ca43529fb4caca48b4e7dcf16ad04209db0e8c38f4cbR747-R754) [[6]](diffhunk://#diff-4241db9b873ce8235c14ca43529fb4caca48b4e7dcf16ad04209db0e8c38f4cbR806-R879) [[7]](diffhunk://#diff-4241db9b873ce8235c14ca43529fb4caca48b4e7dcf16ad04209db0e8c38f4cbR918-R922) [[8]](diffhunk://#diff-4241db9b873ce8235c14ca43529fb4caca48b4e7dcf16ad04209db0e8c38f4cbR950-R1088)
  - Update sample usage of `DidPeer.getDid` to specify `preferredNumalgo` (`test/did/did_peer_test.dart`)

**Documentation and Imports**

* Improved documentation for the new parameter and updated imports to support the changes. (`lib/src/did/did_manager/did_peer_manager.dart`, `lib/src/did/did_peer.dart`) [[1]](diffhunk://#diff-ff2fd81737377d8f0859516803dd6cb0a70c479e31d297814587ed7cc8a1787bR9) [[2]](diffhunk://#diff-6dafcdfed2ba45dea8288ff5722c52eb993f8c3cc9ae039364e163399bf3c06dR389-R391)

These changes make DID peer algorithm selection explicit, robust, and predictable, preventing accidental generation of `did:peer:0` identifiers and aligning with the latest specifications and design plans.