### PR TITLE
fix: remove intl package dependency

### DIFF
--- a/lib/src/credentials/parsers/verifiable_data_parser.dart
+++ b/lib/src/credentials/parsers/verifiable_data_parser.dart
@@ -1,6 +1,3 @@
-/// Base type for decoded verifiable data.
-abstract class DecodedType {}
-
 /// Interface for parsers that decode serialized verifiable data.
 ///
 /// Implementations of this interface provide methods to check if data can be

--- a/lib/src/did/did_webvh/did_webvh.dart
+++ b/lib/src/did/did_webvh/did_webvh.dart
@@ -131,6 +131,7 @@ class DidWebVhDocumentMetadata extends DidDocumentMetadata {
     this.versionNumber,
   });
 
+  /// Converts this metadata object to a JSON-serializable map.
   Map<String, dynamic> toJson() {
     return {
       'scid': scid,

--- a/lib/src/did/did_webvh/did_webvh_log.dart
+++ b/lib/src/did/did_webvh/did_webvh_log.dart
@@ -785,9 +785,11 @@ class DidWebVhLog {
     int verifyUpToIndex = entries.length - 1;
 
     var providedParametersCount = 0;
-    resolutionOptions?.versionId != null ? providedParametersCount++ : null;
-    resolutionOptions?.versionNumber != null ? providedParametersCount++ : null;
-    resolutionOptions?.versionTime != null ? providedParametersCount++ : null;
+    if (resolutionOptions != null) {
+      if (resolutionOptions.versionId != null) providedParametersCount++;
+      if (resolutionOptions.versionNumber != null) providedParametersCount++;
+      if (resolutionOptions.versionTime != null) providedParametersCount++;
+    }
 
     if (providedParametersCount > 1) {
       throw SsiException(

--- a/lib/src/did/did_webvh/did_webvh_log.dart
+++ b/lib/src/did/did_webvh/did_webvh_log.dart
@@ -3,10 +3,10 @@ import 'dart:typed_data';
 
 import 'package:base_codecs/base_codecs.dart';
 import 'package:http/http.dart' as http;
-import 'package:intl/intl.dart';
 
 import '../../../ssi.dart';
 import '../../digest_utils.dart';
+import 'did_webvh_timestamp.dart';
 
 /// Downloads a document from the specified URL and returns the response body.
 ///
@@ -50,7 +50,7 @@ Future<String> downloadDocument(
   }
 }
 
-final _WebVhDateFormat = DateFormat('yyyy-MM-ddTHH:mm:ss\'Z\'');
+final _webVhDateFormat = DidWebVhTimestamp();
 
 /// A Data Integrity proof attached to a DID WebVH log entry.
 ///
@@ -173,10 +173,10 @@ class DidWebVhLogEntryProof {
       proofValue: json['proofValue'] as String,
       verificationMethod: json['verificationMethod'] as String,
       created: json['created'] != null
-          ? _WebVhDateFormat.parse(json['created'] as String)
+          ? _webVhDateFormat.parse(json['created'] as String)
           : null,
       expires: json['expires'] != null
-          ? _WebVhDateFormat.parse(json['expires'] as String)
+          ? _webVhDateFormat.parse(json['expires'] as String)
           : null,
     );
   }
@@ -192,8 +192,8 @@ class DidWebVhLogEntryProof {
       'proofPurpose': proofPurpose,
       'proofValue': proofValue,
       'verificationMethod': verificationMethod,
-      if (created != null) 'created': _WebVhDateFormat.format(created!),
-      if (expires != null) 'expires': _WebVhDateFormat.format(expires!),
+      if (created != null) 'created': _webVhDateFormat.format(created!),
+      if (expires != null) 'expires': _webVhDateFormat.format(expires!),
     };
   }
 }
@@ -513,8 +513,7 @@ class DidWebVhLogEntry {
     try {
       // FIXME: This versionTime format is subject to change based on the final spec. second-fractional digits may be added as an optional component
       // If the versionTime format changes, this parsing logic will need to be updated accordingly.
-      entryVersionTime =
-          _WebVhDateFormat.parseUTC(json['versionTime'] as String);
+      entryVersionTime = _webVhDateFormat.parse(json['versionTime'] as String);
     } on FormatException catch (e) {
       throw SsiDidResolutionException(
           message:
@@ -553,10 +552,14 @@ class DidWebVhLogEntry {
     return result;
   }
 
+  /// Serializes this log entry to a JSON map.
+  ///
+  /// Converts the [DidWebVhLogEntry] object into a JSON-serializable map, including all fields and nested objects.
+  /// The [versionTime] is formatted as an ISO8601 string without fractional seconds.
   Map<String, dynamic> toJson() {
     return {
       'versionId': versionId,
-      'versionTime': _WebVhDateFormat.format(versionTime),
+      'versionTime': _webVhDateFormat.format(versionTime),
       'parameters': {
         if (parameters.method != null) 'method': parameters.method!,
         if (parameters.scid != null) 'scid': parameters.scid!,

--- a/lib/src/did/did_webvh/did_webvh_timestamp.dart
+++ b/lib/src/did/did_webvh/did_webvh_timestamp.dart
@@ -1,0 +1,46 @@
+/// Formats and parses did:webvh timestamps as whole-second UTC values.
+class DidWebVhTimestamp {
+  final _pattern = RegExp(
+    r'^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})Z$',
+  );
+
+  /// Formats a [DateTime] as a did:webvh timestamp string.
+  /// It does not include fractional seconds and always uses UTC timezone.
+  String format(DateTime value) {
+    final utcValue = value.toUtc();
+    final year = utcValue.year.toString().padLeft(4, '0');
+    final month = utcValue.month.toString().padLeft(2, '0');
+    final day = utcValue.day.toString().padLeft(2, '0');
+    final hour = utcValue.hour.toString().padLeft(2, '0');
+    final minute = utcValue.minute.toString().padLeft(2, '0');
+    final second = utcValue.second.toString().padLeft(2, '0');
+    return '$year-$month-${day}T$hour:$minute:${second}Z';
+  }
+
+  /// Parses a did:webvh timestamp string into a [DateTime] object.
+  /// The input must be in the format produced by [format], and the resulting
+  /// DateTime will be in UTC.
+  /// Throws a [FormatException] if the input is not a valid did:webvh timestamp.
+  /// The parser is strict and will reject values that do not exactly match the format,
+  /// including those with fractional seconds or incorrect timezone indicators.
+  DateTime parse(String value) {
+    final match = _pattern.firstMatch(value);
+    if (match == null) {
+      throw FormatException('Invalid did:webvh timestamp format', value);
+    }
+
+    final year = int.parse(match.group(1)!);
+    final month = int.parse(match.group(2)!);
+    final day = int.parse(match.group(3)!);
+    final hour = int.parse(match.group(4)!);
+    final minute = int.parse(match.group(5)!);
+    final second = int.parse(match.group(6)!);
+
+    final parsed = DateTime.utc(year, month, day, hour, minute, second);
+    if (format(parsed) != value) {
+      throw FormatException('Invalid did:webvh timestamp value', value);
+    }
+
+    return parsed;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
   ed25519_hd_key: ^2.3.0
   elliptic: ^0.3.11
   http: ^1.4.0
-  intl: ^0.19.0
   json_ld_processor: ^1.0.4
   meta: ^1.15.0
   pointycastle: ^4.0.0

--- a/test/did/did_webvh/did_webvh_test.dart
+++ b/test/did/did_webvh/did_webvh_test.dart
@@ -296,6 +296,44 @@ void main() {
       expect(entry.proof[0].type, equals('DataIntegrityProof'));
     });
 
+    test('should serialize timestamps as whole-second UTC values', () {
+      final entry = DidWebVhLogEntry.fromJson({
+        'versionId': '1-QmHash123',
+        'versionTime': '2024-04-05T07:32:58Z',
+        'parameters': {
+          'method': 'did:webvh:1.0',
+        },
+        'state': {
+          '@context': ['https://www.w3.org/ns/did/v1'],
+          'id': 'did:webvh:QmScid123:example.com',
+        },
+        'proof': [
+          {
+            'type': 'DataIntegrityProof',
+            'cryptosuite': 'eddsa-jcs-2022',
+            'proofPurpose': 'assertionMethod',
+            'verificationMethod': 'did:key:z6MkKey1',
+            'proofValue': 'z5V1',
+            'created': '2024-04-05T07:32:58Z',
+          }
+        ],
+      });
+
+      final proof = DidWebVhLogEntryProof(
+        type: 'DataIntegrityProof',
+        cryptosuite: 'eddsa-jcs-2022',
+        proofPurpose: 'assertionMethod',
+        proofValue: 'z5V1',
+        verificationMethod: 'did:key:z6MkKey1',
+        created: DateTime.parse('2024-04-05T09:32:58.987+02:00'),
+        expires: DateTime.parse('2024-04-05T10:32:58.456+02:00'),
+      );
+
+      expect(entry.toJson()['versionTime'], equals('2024-04-05T07:32:58Z'));
+      expect(proof.toJson()['created'], equals('2024-04-05T07:32:58Z'));
+      expect(proof.toJson()['expires'], equals('2024-04-05T08:32:58Z'));
+    });
+
     test('should extract version number from versionId', () {
       final json = {
         'versionId': '42-QmHash123',
@@ -551,6 +589,45 @@ void main() {
           'message',
           contains('Invalid DID WebVh Log Entry versionTime format.'),
         )),
+      );
+    });
+
+    test('should throw SsiException when versionTime has fractional seconds',
+        () {
+      final json = {
+        'versionId': '1-QmHash',
+        'versionTime': '2024-04-05T07:32:58.123Z',
+        'parameters': <dynamic, dynamic>{},
+        'state': {
+          '@context': <String>['https://www.w3.org/ns/did/v1'],
+          'id': 'did:webvh:scid:example.com',
+        },
+        'proof': <Map<String, dynamic>>[],
+      };
+
+      expect(
+        () => DidWebVhLogEntry.fromJson(json),
+        throwsA(isA<SsiDidResolutionException>().having(
+          (e) => e.toString(),
+          'message',
+          contains('Invalid DID WebVh Log Entry versionTime format.'),
+        )),
+      );
+    });
+
+    test(
+        'should throw FormatException when proof timestamp has fractional seconds',
+        () {
+      expect(
+        () => DidWebVhLogEntryProof.fromJson({
+          'type': 'DataIntegrityProof',
+          'cryptosuite': 'eddsa-jcs-2022',
+          'proofPurpose': 'assertionMethod',
+          'verificationMethod': 'did:key:z6MkKey1',
+          'proofValue': 'z5V1',
+          'created': '2024-04-05T07:32:58.123Z',
+        }),
+        throwsA(isA<FormatException>()),
       );
     });
   });


### PR DESCRIPTION
- extract logic to parse did webVH timestamps without fractional seconds into a class
- remove intl package dependency
- remove unused `DecodedType` class
- minor cleanups