### PR TITLE
fix: cache RevocationList2020 JSON-LD context

### DIFF
--- a/lib/src/credentials/proof/base_secp256k1_verifier.dart
+++ b/lib/src/credentials/proof/base_secp256k1_verifier.dart
@@ -988,4 +988,45 @@ final _documentCache = <Uri, RemoteDocument>{
 }
 '''),
   ),
+  Uri.parse('https://w3id.org/vc-revocation-list-2020/v1'): RemoteDocument(
+    document: jsonDecode(r'''
+{
+  "@context": {
+    "@protected": true,
+    "RevocationList2020Credential": {
+      "@id": "https://w3id.org/vc-revocation-list-2020#RevocationList2020Credential",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "description": "http://schema.org/description",
+        "name": "http://schema.org/name"
+      }
+    },
+    "RevocationList2020": {
+      "@id": "https://w3id.org/vc-revocation-list-2020#RevocationList2020",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "encodedList": "https://w3id.org/vc-revocation-list-2020#encodedList"
+      }
+    },
+    "RevocationList2020Status": {
+      "@id": "https://w3id.org/vc-revocation-list-2020#RevocationList2020Status",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "revocationListCredential": {
+          "@id": "https://w3id.org/vc-revocation-list-2020#revocationListCredential",
+          "@type": "@id"
+        },
+        "revocationListIndex": "https://w3id.org/vc-revocation-list-2020#revocationListIndex"
+      }
+    }
+  }
+}
+'''),
+  ),
 };

--- a/lib/src/credentials/proof/ecdsa_secp256k1_signature2019_suite.dart
+++ b/lib/src/credentials/proof/ecdsa_secp256k1_signature2019_suite.dart
@@ -639,6 +639,47 @@ class Secp256k1Signature2019Generator extends EmbeddedProofSuiteCreateOptions
 }
 '''),
     ),
+    Uri.parse('https://w3id.org/vc-revocation-list-2020/v1'): RemoteDocument(
+      document: jsonDecode(r'''
+{
+  "@context": {
+    "@protected": true,
+    "RevocationList2020Credential": {
+      "@id": "https://w3id.org/vc-revocation-list-2020#RevocationList2020Credential",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "description": "http://schema.org/description",
+        "name": "http://schema.org/name"
+      }
+    },
+    "RevocationList2020": {
+      "@id": "https://w3id.org/vc-revocation-list-2020#RevocationList2020",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "encodedList": "https://w3id.org/vc-revocation-list-2020#encodedList"
+      }
+    },
+    "RevocationList2020Status": {
+      "@id": "https://w3id.org/vc-revocation-list-2020#RevocationList2020Status",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "revocationListCredential": {
+          "@id": "https://w3id.org/vc-revocation-list-2020#revocationListCredential",
+          "@type": "@id"
+        },
+        "revocationListIndex": "https://w3id.org/vc-revocation-list-2020#revocationListIndex"
+      }
+    }
+  }
+}
+'''),
+    ),
   };
 }
 


### PR DESCRIPTION
## Problem
Intermittent `JsonLdException: JSON-LD normalization failed` errors occurring during revocation list credential signing. Root cause: the `https://w3id.org/vc-revocation-list-2020/v1` context is fetched live from the network, which involves a redirect chain  (w3id.org -> w3c-ccg.github.io) that can fail transiently.

## Solution
Added the RevocationList2020 JSON-LD context to the static document cache in:
- `base_secp256k1_verifier.dart`
- `ecdsa_secp256k1_signature2019_suite.dart`

This matches how other standard contexts (credentials/v1, credentials/v2, security/v1, security/v2)  are already cached, eliminating network dependency during VC signing operations.