### PR TITLE
fix: verify did:webvh SCID over the published log entry

### DIFF
--- a/lib/src/did/did_webvh/did_webvh_log.dart
+++ b/lib/src/did/did_webvh/did_webvh_log.dart
@@ -489,13 +489,25 @@ class DidWebVhLogEntry {
   /// Must use proofPurpose set to "assertionMethod".
   final List<DidWebVhLogEntryProof> proof;
 
+  /// The entry exactly as published in the JSON Lines log.
+  ///
+  /// SCID and entry-hash verification MUST run over the published entry
+  /// (did:webvh 1.0, SCID Generation and Verification: "treat the resulting
+  /// log entry as a string"). Rebuilding the entry from typed fields via
+  /// [toJson] can change the canonical form for any value the typed model does
+  /// not preserve verbatim, such as a single-element `service.type` array that
+  /// collapses to a string, which makes the recomputed hash differ from the
+  /// published SCID.
+  final Map<String, dynamic> _sourceJson;
+
   DidWebVhLogEntry._({
     required this.versionId,
     required this.versionTime,
     required this.parameters,
     required this.state,
     required this.proof,
-  });
+    required Map<String, dynamic> sourceJson,
+  }) : _sourceJson = sourceJson;
 
   /// Creates a [DidWebVhLogEntry] from a JSON object.
   ///
@@ -532,6 +544,7 @@ class DidWebVhLogEntry {
       proof: (json['proof'] as List)
           .map((e) => DidWebVhLogEntryProof.fromJson(e as Map<String, dynamic>))
           .toList(),
+      sourceJson: json,
     );
   }
 
@@ -541,12 +554,15 @@ class DidWebVhLogEntry {
   /// The returned map includes all fields except for the proof, and allows the versionId to be replaced
   /// with a custom value (e.g., "{SCID}").
   ///
+  /// The published JSON ([_sourceJson]) is used rather than the typed [toJson]
+  /// representation so the hash matches the bytes the controller signed.
+  ///
   /// - [newVersionId]: The versionId value to use in the returned map (e.g., "{SCID}" or a previous versionId).
   ///
   /// Returns a map suitable for canonicalization and hashing.
   Map<String, dynamic> buildMapFromEntryWithVersionIdAndStrippedProof(
       String newVersionId) {
-    final result = toJson();
+    final result = jsonDecode(jsonEncode(_sourceJson)) as Map<String, dynamic>;
     result.remove('proof');
     result['versionId'] = newVersionId;
     return result;

--- a/test/did/did_webvh/did_webvh_scid_service_type_test.dart
+++ b/test/did/did_webvh/did_webvh_scid_service_type_test.dart
@@ -1,0 +1,28 @@
+import 'package:ssi/ssi.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SCID verification over the published log entry', () {
+    final didWebVhUrl = DidWebVhUrl.fromUrlString(
+        'did:webvh:QmY29n4pk1Ge8suzgqhqEwR38no6m9zTrcpuXjn6rXmfQj:mediator.example.com');
+
+    test('verifies an entry whose service type is a single-element array',
+        () async {
+      const jsonLines =
+          r'{"versionId":"1-QmNjd1quEJC6Mfq37yn7V1k9U5ykUzigFca1zwukNryqzW","versionTime":"2026-06-13T17:12:20Z","parameters":{"method":"did:webvh:1.0","scid":"QmY29n4pk1Ge8suzgqhqEwR38no6m9zTrcpuXjn6rXmfQj","updateKeys":["z6MktxYNded4t8Ff5EpGM4sNYJHn5sfA27hdzJgdkcJ2ToQY"],"portable":true,"nextKeyHashes":["z6MkvNCJm9feeCxRK4oCt461PNQkvc1bt7JpfmtNx7gUv9kj"]},"state":{"@context":["https://www.w3.org/ns/did/v1","https://w3id.org/security/multikey/v1","https://didcomm.org/messaging/v2"],"assertionMethod":["did:webvh:QmY29n4pk1Ge8suzgqhqEwR38no6m9zTrcpuXjn6rXmfQj:mediator.example.com#key-0"],"authentication":["did:webvh:QmY29n4pk1Ge8suzgqhqEwR38no6m9zTrcpuXjn6rXmfQj:mediator.example.com#key-0"],"id":"did:webvh:QmY29n4pk1Ge8suzgqhqEwR38no6m9zTrcpuXjn6rXmfQj:mediator.example.com","keyAgreement":["did:webvh:QmY29n4pk1Ge8suzgqhqEwR38no6m9zTrcpuXjn6rXmfQj:mediator.example.com#key-1"],"service":[{"id":"did:webvh:QmY29n4pk1Ge8suzgqhqEwR38no6m9zTrcpuXjn6rXmfQj:mediator.example.com#service","serviceEndpoint":[{"accept":["didcomm/v2"],"routingKeys":[],"uri":"https://mediator.example.com/mediator/v1"},{"accept":["didcomm/v2"],"routingKeys":[],"uri":"wss://mediator.example.com/mediator/v1/ws"}],"type":["DIDCommMessaging"]},{"id":"did:webvh:QmY29n4pk1Ge8suzgqhqEwR38no6m9zTrcpuXjn6rXmfQj:mediator.example.com#auth","serviceEndpoint":"https://mediator.example.com/mediator/v1/authenticate","type":["Authentication"]}],"verificationMethod":[{"controller":"did:webvh:QmY29n4pk1Ge8suzgqhqEwR38no6m9zTrcpuXjn6rXmfQj:mediator.example.com","id":"did:webvh:QmY29n4pk1Ge8suzgqhqEwR38no6m9zTrcpuXjn6rXmfQj:mediator.example.com#key-0","publicKeyMultibase":"z6MkoL8qQrVju4uGyCWGfU2HH8iBYE9Nc8MbZbK4pgSrMETL","type":"Multikey"},{"controller":"did:webvh:QmY29n4pk1Ge8suzgqhqEwR38no6m9zTrcpuXjn6rXmfQj:mediator.example.com","id":"did:webvh:QmY29n4pk1Ge8suzgqhqEwR38no6m9zTrcpuXjn6rXmfQj:mediator.example.com#key-1","publicKeyMultibase":"z6LSd9YCdimAYMotGmeakbnHrqV3GxhBuzzt1GdVis3zKgvm","type":"Multikey"}]},"proof":[{"type":"DataIntegrityProof","cryptosuite":"eddsa-jcs-2022","created":"2026-06-13T17:12:20Z","verificationMethod":"did:key:z6MktxYNded4t8Ff5EpGM4sNYJHn5sfA27hdzJgdkcJ2ToQY#z6MktxYNded4t8Ff5EpGM4sNYJHn5sfA27hdzJgdkcJ2ToQY","proofPurpose":"assertionMethod","proofValue":"z3V4DPrHD3wmijMGJen6BN6EGb1nw5VJereUYrBvJBfT6QpSvCJ1oSNbrXCyGn6bfCk9CcCqhyUMHNaKnaFEYw5c4"}]}';
+
+      final log = DidWebVhLog.fromJsonLines(jsonLines);
+
+      await expectLater(
+        log.verify(
+          options: DidWebVhResolutionOptions(
+            resolvingDidUrl: didWebVhUrl,
+            skipResolvedDidDocScidVerification: true,
+            skipWitnessVerification: true,
+          ),
+        ),
+        completes,
+      );
+    });
+  });
+}


### PR DESCRIPTION
SCID and entry-hash verification rebuilt the first log entry from the typed DidWebVhLogEntry via toJson() before canonicalizing and hashing it. The did:webvh 1.0 spec (SCID Generation and Verification) requires hashing the log entry as published ("treat the resulting log entry as a string"), and the typed round-trip does not preserve every value verbatim. In particular a DID document service whose `type` is a single-element array, e.g. `"type": ["DIDCommMessaging"]`, is collapsed to the string `"type": "DIDCommMessaging"`. After JCS canonicalization an array and a string are distinct values, so the recomputed SCID no longer matches the published one and resolution fails for a spec-valid DID.

DID Core permits service `type` to be a string or an array of strings, and the array form is produced by didwebvh-rs (the reference Rust implementation) among others, so these DIDs were unresolvable.

Retain the entry's published JSON on parse and canonicalize that for SCID and entry-hash verification, so the hash is computed over the bytes the controller signed regardless of how the typed model serializes them.

Adds a regression test using a real didwebvh-rs-minted entry whose DID document service type is a single-element array; it fails before this change and passes after.