### PR TITLE
refactor!: remove unused DidWebVhLogEntry.toJson()

### DIFF
--- a/lib/src/did/did_webvh/did_webvh_log.dart
+++ b/lib/src/did/did_webvh/did_webvh_log.dart
@@ -493,11 +493,10 @@ class DidWebVhLogEntry {
   ///
   /// SCID and entry-hash verification MUST run over the published entry
   /// (did:webvh 1.0, SCID Generation and Verification: "treat the resulting
-  /// log entry as a string"). Rebuilding the entry from typed fields via
-  /// [toJson] can change the canonical form for any value the typed model does
-  /// not preserve verbatim, such as a single-element `service.type` array that
-  /// collapses to a string, which makes the recomputed hash differ from the
-  /// published SCID.
+  /// log entry as a string"). Rebuilding the entry from the typed fields can
+  /// change the canonical form for any value the typed model does not preserve
+  /// verbatim, such as a single-element `service.type` array that collapses to
+  /// a string, which makes the recomputed hash differ from the published SCID.
   final Map<String, dynamic> _sourceJson;
 
   DidWebVhLogEntry._({
@@ -554,8 +553,8 @@ class DidWebVhLogEntry {
   /// The returned map includes all fields except for the proof, and allows the versionId to be replaced
   /// with a custom value (e.g., "{SCID}").
   ///
-  /// The published JSON ([_sourceJson]) is used rather than the typed [toJson]
-  /// representation so the hash matches the bytes the controller signed.
+  /// The published JSON ([_sourceJson]) is used rather than rebuilding the map
+  /// from the typed fields so the hash matches the bytes the controller signed.
   ///
   /// - [newVersionId]: The versionId value to use in the returned map (e.g., "{SCID}" or a previous versionId).
   ///
@@ -566,32 +565,6 @@ class DidWebVhLogEntry {
     result.remove('proof');
     result['versionId'] = newVersionId;
     return result;
-  }
-
-  /// Serializes this log entry to a JSON map.
-  ///
-  /// Converts the [DidWebVhLogEntry] object into a JSON-serializable map, including all fields and nested objects.
-  /// The [versionTime] is formatted as an ISO8601 string without fractional seconds.
-  Map<String, dynamic> toJson() {
-    return {
-      'versionId': versionId,
-      'versionTime': _webVhDateFormat.format(versionTime),
-      'parameters': {
-        if (parameters.method != null) 'method': parameters.method!,
-        if (parameters.scid != null) 'scid': parameters.scid!,
-        if (parameters.updateKeys != null) 'updateKeys': parameters.updateKeys!,
-        if (parameters.nextKeyHashes != null)
-          'nextKeyHashes': parameters.nextKeyHashes!,
-        if (parameters.witness != null) 'witness': parameters.witness!.toJson(),
-        if (parameters.watchers != null) 'watchers': parameters.watchers!,
-        if (parameters.portable != null) 'portable': parameters.portable!,
-        if (parameters.deactivated != null)
-          'deactivated': parameters.deactivated!,
-        if (parameters.ttl != null) 'ttl': parameters.ttl!,
-      },
-      'state': state.toJson(),
-      'proof': proof.map((e) => e.toJson()).toList(),
-    };
   }
 
   /// Extracts the version number from the versionId.

--- a/test/did/did_webvh/did_webvh_test.dart
+++ b/test/did/did_webvh/did_webvh_test.dart
@@ -297,28 +297,6 @@ void main() {
     });
 
     test('should serialize timestamps as whole-second UTC values', () {
-      final entry = DidWebVhLogEntry.fromJson({
-        'versionId': '1-QmHash123',
-        'versionTime': '2024-04-05T07:32:58Z',
-        'parameters': {
-          'method': 'did:webvh:1.0',
-        },
-        'state': {
-          '@context': ['https://www.w3.org/ns/did/v1'],
-          'id': 'did:webvh:QmScid123:example.com',
-        },
-        'proof': [
-          {
-            'type': 'DataIntegrityProof',
-            'cryptosuite': 'eddsa-jcs-2022',
-            'proofPurpose': 'assertionMethod',
-            'verificationMethod': 'did:key:z6MkKey1',
-            'proofValue': 'z5V1',
-            'created': '2024-04-05T07:32:58Z',
-          }
-        ],
-      });
-
       final proof = DidWebVhLogEntryProof(
         type: 'DataIntegrityProof',
         cryptosuite: 'eddsa-jcs-2022',
@@ -329,7 +307,6 @@ void main() {
         expires: DateTime.parse('2024-04-05T10:32:58.456+02:00'),
       );
 
-      expect(entry.toJson()['versionTime'], equals('2024-04-05T07:32:58Z'));
       expect(proof.toJson()['created'], equals('2024-04-05T07:32:58Z'));
       expect(proof.toJson()['expires'], equals('2024-04-05T08:32:58Z'));
     });


### PR DESCRIPTION
## What

Removes the now-unused `DidWebVhLogEntry.toJson()` method.

## Why

Follow-up to #290. That fix made SCID and entry-hash verification run over the entry's **published JSON** (`_sourceJson`) instead of a typed round-trip, because rebuilding from typed fields can change the canonical form (e.g. a single-element `service.type` array collapsing to a string) and break the recomputed SCID.

After that change, `DidWebVhLogEntry.toJson()` has **no production caller** — this is a read/resolve-only library with no log-writing/signing path. Its only remaining use was one date-format unit test. Keeping it around is a footgun: it invites re-serializing the typed model for hashing, which is exactly the bug #290 fixed.

This addresses the review question on #290 about whether `toJson()` should stay.

## Changes

- Remove `DidWebVhLogEntry.toJson()`.
- Drop the obsolete entry-level assertion from the "whole-second UTC" test; proof-level serialization coverage (`DidWebVhLogEntryProof.toJson()`) remains.
- Tidy two doc comments that referenced the removed method.

## Breaking change

`DidWebVhLogEntry.toJson()` is public (exported via `lib/ssi.dart`) and has been removed.

## Verification

- `dart analyze` — no issues.
- `dart test test/did/did_webvh/` — all 152 tests pass (incl. the #290 SCID regression).
